### PR TITLE
Add support for combustion engine heating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This platform plugin allows you to see some information from volkswagen carnet r
 
 It also allows you to trigger some functions like start climatisation if your car supports that.
 
+Remote engine heating is supported for combustion engine vehicles that uses the carnet portal together provided S-PIN. Probably not availabel for all car models.
+
 Installation
 ------------
 
@@ -18,15 +20,56 @@ Add a volkswagencarnet configuration block to your `<config dir>/configuration.y
 volkswagencarnet:
     username: <username to volkswagen carnet>
     password: <password to volkswagen carnet>
+    spin: <S-PIN to volkswagen carnet>  
     scan_interval: 
         minutes: 2
     name:
         wvw1234567812356: 'Passat GTE'
+    resources:
+        - combustion_engine_heating
+        - position
+        - distance
+        - service_inspection
+        - oil_inspection
+        - door_locked
+        - trunk_locked
+        - request_in_progress
 ```
 
-scan_interval: specify in minutes how often to fetch status data from carnet (optional, default 5 min, minimum 1 min)
+* **spin:** (optional) required for supporting combustion engine heating start/stop.
 
-name: set a friendly name of your car you can use the name setting as in confiugration example.
+* **scan_interval:** (optional) specify in minutes how often to fetch status data from carnet. (default 5 min, minimum 1 min)
+
+* **name:** (optional) set a friendly name of your car you can use the name setting as in confiugration example.
+
+* **resources:** (optional) list of resources that should be enabled. (by default all resources is enabled).
+
+Available resources:
+```
+    'position',
+    'distance',
+    'climatisation',
+    'window_heater',
+    'combustion_engine_heating',
+    'charging',
+    'battery_level',
+    'fuel_level',
+    'service_inspection',
+    'oil_inspection',
+    'last_connected',
+    'charging_time_left',
+    'electric_range',
+    'combustion_range',
+    'combined_range',
+    'charge_max_ampere',
+    'climatisation_target_temperature',
+    'external_power',
+    'parking_light',
+    'climatisation_without_external_power',
+    'door_locked',
+    'trunk_locked',
+    'request_in_progress'
+```
 
 Example of entities
 ------------

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -24,7 +24,7 @@ CONF_SPIN = 'spin'
 # Temporary requirment to get this to work in HA.
 # Until it can get merged to original repo.
 REQUIREMENTS = [
-    'https://github.com/Fredrik-Oberg/volkswagencarnet/archive/4.1.3.zip#volkswagencarnet==4.1.3']
+    'https://github.com/Fredrik-Oberg/volkswagencarnet/archive/4.1.4.zip#volkswagencarnet==4.1.4']
 
 SIGNAL_STATE_UPDATED = '{}.updated'.format(DOMAIN)
 
@@ -45,7 +45,7 @@ RESOURCES = [
     'distance',
     'climatisation',
     'window_heater',
-    'remote_access_heating',
+    'combustion_engine_heating',
     'charging',
     'battery_level',
     'fuel_level',

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -24,7 +24,7 @@ CONF_SPIN = 'spin'
 # Temporary requirment to get this to work in HA.
 # Until it can get merged to original repo.
 REQUIREMENTS = [
-    'https://github.com/Fredrik-Oberg/volkswagencarnet/archive/4.1.0.zip#volkswagencarnet==4.1.0']
+    'https://github.com/Fredrik-Oberg/volkswagencarnet/archive/4.1.3.zip#volkswagencarnet==4.1.3']
 
 SIGNAL_STATE_UPDATED = '{}.updated'.format(DOMAIN)
 


### PR DESCRIPTION
This is very much dependent on the PR of https://github.com/robinostlund/volkswagencarnet/pull/12

Creating a PR, even though the main repo has not been approved and mergerd yet, if people want to contribute and test this out. 
It has been some talk about it in issues #40 #48 and maybe others.

To get this working you need to:

1. Replace the `custom_components/volkswagencarnet/__init__.py` with the one in this PR.
2. The Home assistant config needs to be updated with the S-PIN
Also good to now is that you can provide the resources that you care about. Since there is resources that does not interest an "non-electric" car 😄 .
Here is an example of my HA `configuration.yaml` file:
```
volkswagencarnet:
  username: redacted
  password: redacted
  spin: 1234
  scan_interval: 
    minutes: 1
  resources:
    - combustion_engine_heating
    - position
    - distance
    - service_inspection
    - oil_inspection
    - door_locked
    - trunk_locked
    - request_in_progress
```
An issue that I have not managed to solve is that.
After turning on/off the remote heater the state for it is not updated correctly. Since the heater (and other states) is cached until an update is triggered, that is what the config setting `scan_interval` is using.
I would like the state to be updated once a action is called. But it looks to be quite a lot of code changes and both Python and HA deving is new to me 😞 . 
