### PR TITLE
Add interval to request car to report its state

### DIFF
--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -196,6 +196,10 @@ async def async_setup(hass, config):
                 return False
 
             return True
+        
+        except:
+            # This is actually not critical so...
+            pass
 
     async def update(now):
         """Update status from Volkswagen Carnet"""


### PR DESCRIPTION
Some cars needs to be requested for an update. This can be done via Portal by clicking "Generate report". Once car gets connected to WLAN – it sends information data.

Currently for this models we need to do it manually on Portal. This requests can be made only some limited amount of times per month (ie. 30/month), so user needs to plan it carefully.

This PR adds configuration to enable "report requesting" and possibility to configure interval in which report request should be send – it defaults to `days=1`.

This works only with robinostlund/volkswagencarnet#106 merged.