### PR TITLE
Fix for serialize error when setting up via config flow

### DIFF
--- a/custom_components/volkswagencarnet/config_flow.py
+++ b/custom_components/volkswagencarnet/config_flow.py
@@ -114,6 +114,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_select_instruments(self, user_input=None):
         if user_input is not None:
             self._init_info[CONF_RESOURCES] = user_input[CONF_RESOURCES]
+            del self._init_info["CONF_VEHICLES"]
 
             if self._init_info[CONF_NAME] is None:
                 self._init_info[CONF_NAME] = self._init_info[CONF_VEHICLE]


### PR DESCRIPTION
Don't persist the vehicle instruments in the config entry since it was not serializable and not supposed to be stored.
Should resolve #244