### PR TITLE
Climte modes and attrs

### DIFF
--- a/custom_components/volkswagencarnet/climate.py
+++ b/custom_components/volkswagencarnet/climate.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
+    HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
@@ -16,7 +17,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 
-SUPPORT_HVAC = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+SUPPORT_HVAC = [HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_OFF]
 
 from . import DATA, DATA_KEY, DOMAIN, VolkswagenEntity
 
@@ -61,9 +62,14 @@ class VolkswagenClimate(VolkswagenEntity, ClimateEntity):
         """Return hvac operation ie. heat, cool mode.
         Need to be one of HVAC_MODE_*.
         """
-        if self.instrument.hvac_mode:
-            return HVAC_MODE_HEAT
-        return HVAC_MODE_OFF
+        if not self.instrument.hvac_mode:
+            return HVAC_MODE_OFF
+
+        hvac_modes = {
+            "HEATING": HVAC_MODE_HEAT,
+            "COOLING": HVAC_MODE_COOL,
+        }
+        return hvac_modes.get(self.instrument.hvac_mode, HVAC_MODE_OFF)
 
     @property
     def hvac_modes(self):

--- a/custom_components/volkswagencarnet/manifest.json
+++ b/custom_components/volkswagencarnet/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "config_flow": true,
     "codeowners": ["@robinostlund"],
-    "requirements": ["volkswagencarnet==4.4.24"],
+    "requirements": ["volkswagencarnet==4.4.26"],
     "version": "v0.0.0"
 }

--- a/custom_components/volkswagencarnet/switch.py
+++ b/custom_components/volkswagencarnet/switch.py
@@ -2,7 +2,7 @@
 Support for Volkswagen WeConnect Platform
 """
 import logging
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from homeassistant.helpers.entity import ToggleEntity
 
@@ -64,5 +64,3 @@ class VolkswagenSwitch(VolkswagenEntity, ToggleEntity):
     @property
     def state_attributes(self) -> Optional[Dict[str, Any]]:
         return self.instrument.attributes
-
-

--- a/custom_components/volkswagencarnet/switch.py
+++ b/custom_components/volkswagencarnet/switch.py
@@ -2,6 +2,7 @@
 Support for Volkswagen WeConnect Platform
 """
 import logging
+from typing import Optional, Dict, Any
 
 from homeassistant.helpers.entity import ToggleEntity
 
@@ -59,3 +60,9 @@ class VolkswagenSwitch(VolkswagenEntity, ToggleEntity):
     @property
     def assumed_state(self):
         return self.instrument.assumed_state
+
+    @property
+    def state_attributes(self) -> Optional[Dict[str, Any]]:
+        return self.instrument.attributes
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-volkswagencarnet==4.4.24
+volkswagencarnet==4.4.26


### PR DESCRIPTION
* Adds correct hvac mode to climate
* Adds mode, ventilation, remaining time and outdoor temp as attrs to CombEngine toggle

Will bump version of `volkswagencarnet` once https://github.com/robinostlund/volkswagencarnet/pull/110 is merged.