### PR TITLE
Let Home Assistant automatically install component requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Make sure you have an account on Volkswagen We Connect.
 
 Clone or copy the repository and copy the folder 'homeassistant-volkswagencarnet/custom_component/volkswagencarnet' into '<config dir>/custom_components'
 
-#### Installing dependencies
-Note that only the packaged releases (zip file) have the dependencies configured so that Home Assistant can find them automatically, but if you use the source code or git branch, you need to manually install the correct versions of all dependencies also using something like `pip install -r requirements.txt`.
-
 ## Configuration
 * Restart Home Assistant
 * Add and configure the component via the UI: Configuration > Integrations > search for "Volkswagen We Connect" and follow the wizard to configure (use your We Connect credentials)

--- a/custom_components/volkswagencarnet/manifest.json
+++ b/custom_components/volkswagencarnet/manifest.json
@@ -6,7 +6,7 @@
     "dependencies": [],
     "config_flow": true,
     "codeowners": ["@robinostlund"],
-    "requirements": [],
+    "requirements": ["pytz", "volkswagencarnet==4.4.57"],
     "version": "v0.0.0",
     "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Code quality improvements to existing code or addition of tests

I noticed in the setup instructions that users must manually install the requirements. Home Assistant can automatically do this if the requirements are defined in the `manifest.json`.

I wanted to limit this PR to only this change, but I would also suggest removing the empty array `dependencies` and setting the actual version value instead of `"version": "v0.0.0",`

For the future, you need to maintain the version used in the `requirements`, I don't think depandabot would do this automatically. (The same for the version field, if you want to set the version.) But I do think this is actually better than letting users manually install requirements.