### PR TITLE
asyncio is built in since python 3.4 

### DIFF
--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -1,5 +1,4 @@
 """We Connect custom integration for Home Assistant."""
-import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Optional, Any, Union, Mapping


### PR DESCRIPTION
## Type of change
- [ ] Dependency upgrade
- [ X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests

I am using the linuxserver/homeassistant image which uses python 3.11.
 
On my installation I removed what is in this pull request, because since python 3.4 asyncio has been built into python-core. The external asyncio project is deprecated and the repo archived: https://github.com/python/asyncio

Since this package runs well with python 3.11 all systems should already have it built in.

Installing the old external asyncio causes issues when PYTHONPATH is set to a folder containing the external package.

See here: https://github.com/linuxserver/docker-homeassistant/issues/79

Thanks
