### PR TITLE
Reorganize entities by categories

### DIFF
--- a/custom_components/volkswagencarnet/binary_sensor.py
+++ b/custom_components/volkswagencarnet/binary_sensor.py
@@ -5,6 +5,7 @@ from typing import Union
 from homeassistant.components.binary_sensor import DEVICE_CLASSES, BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from . import VolkswagenEntity
 from .const import DATA_KEY, DATA, DOMAIN, UPDATE_CALLBACK
@@ -54,3 +55,11 @@ class VolkswagenBinarySensor(VolkswagenEntity, BinarySensorEntity):
             return self.instrument.device_class
         _LOGGER.warning(f"Unknown device class {self.instrument.device_class}")
         return None
+
+    @property
+    def entity_category(self) -> Union[EntityCategory, str, None]:
+        """Return entity category."""
+        if self.instrument.entity_type == "diag":
+            return EntityCategory.DIAGNOSTIC
+        if self.instrument.entity_type == "config":
+            return EntityCategory.CONFIG

--- a/custom_components/volkswagencarnet/sensor.py
+++ b/custom_components/volkswagencarnet/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from . import VolkswagenEntity
 from .const import DATA_KEY, DATA, DOMAIN, UPDATE_CALLBACK
@@ -79,3 +80,11 @@ class VolkswagenSensor(VolkswagenEntity, SensorEntity):
             return self.instrument.state_class
         _LOGGER.warning(f"Unknown state class {self.instrument.state_class}")
         return None
+
+    @property
+    def entity_category(self) -> Union[EntityCategory, str, None]:
+        """Return entity category."""
+        if self.instrument.entity_type == "diag":
+            return EntityCategory.DIAGNOSTIC
+        if self.instrument.entity_type == "config":
+            return EntityCategory.CONFIG

--- a/custom_components/volkswagencarnet/switch.py
+++ b/custom_components/volkswagencarnet/switch.py
@@ -93,6 +93,14 @@ class VolkswagenSwitch(VolkswagenEntity, ToggleEntity):
         self.notify_updated()
 
     @property
+    def entity_category(self) -> Union[EntityCategory, str, None]:
+        """Return entity category."""
+        if self.instrument.entity_type == "diag":
+            return EntityCategory.DIAGNOSTIC
+        if self.instrument.entity_type == "config":
+            return EntityCategory.CONFIG
+
+    @property
     def assumed_state(self):
         """Return state assumption."""
         return self.instrument.assumed_state


### PR DESCRIPTION
## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests

Add support for EntityCategory as part of the preparation to re-enable configuration and control switches.
Some sensors and switches are moved to the proper categories: Configuration and Diagnostic

![Screenshot 2024-01-16 at 22 02 28](https://github.com/robinostlund/homeassistant-volkswagencarnet/assets/630000/9d5614eb-f657-4acf-8878-c10b2886d491)
