### PR TITLE
v5.0.3

### DIFF
--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -118,11 +118,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UNDO_UPDATE_LISTENER: entry.add_update_listener(_async_update_listener),
     }
 
-    for component in components:
-        coordinator.platforms.append(component)
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    coordinator.platforms.extend(components)
+    await hass.config_entries.async_forward_entry_setups(entry, components)
 
     return True
 


### PR DESCRIPTION
### Change Log:
- Fix warning introduced in HA 2024.7 (https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
