### PR TITLE
Prevent bot to stale already acknowledged issues/FR

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -20,4 +20,6 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-all-milestones: true
+          exempt-issue-labels: 'acknowledged'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At the moment the gitactions-bot tries to set the `stale` label even on issues/feature requests already marked as acknowledged or even on milestones (see #627 for example).

This modification should tell the bot to avoid those types of issues.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
