### PR TITLE
Adding VIN to Entity Attributes

### DIFF
--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -397,6 +397,7 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         attributes = dict(
             self.instrument.attributes,
             model=f"{self.vehicle.model}/{self.vehicle.model_year}",
+            vin=self.vin,
             last_updated=self.instrument.last_refresh,
         )
 


### PR DESCRIPTION
Adding the VIN to the Attributes of the Entity.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests


## additional information
The VIN is part of the Device and Entity Name, which can be changed / Renamed after the Setup.
If you want to identify a specific entity, it could be helpful to have the VIN within the attributes, as it is part of the information given to identify the vehicle.

![image](https://github.com/user-attachments/assets/2286d555-f902-47d7-8ecc-1713ac6c4f92)
