### PR TITLE
v5.4.2

### DIFF
--- a/custom_components/volkswagencarnet/services.yaml
+++ b/custom_components/volkswagencarnet/services.yaml
@@ -32,7 +32,7 @@ update_schedule:
           step: 1
     timer_type:
       name: Timer type
-      description: The timer type. Departure Timer (Legacy) or AC Departure Timer (ID. Series)
+      description: The timer type. Departure Timer (Non-ID. Series) or AC Departure Timer (ID. Series)
       required: true
       selector:
         select:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-volkswagencarnet==5.4.1
+volkswagencarnet==5.4.2


### PR DESCRIPTION
## Changes

### Maintenance:

- fix(vehicle): only fetch data for discovered active services  

  Previously, the update() method called get_selectivestatus with a hardcoded list of services, regardless of whether they were discovered as active for the vehicle. This caused unnecessary API calls for services not available on the vehicle (e.g., TRIP_STATISTICS, FUEL_STATUS on ID. Series vehicles).  Now the update() method: - Dynamically builds the service list based on discovered active services - Only calls get_parkingposition() if PARKING_POSITION is active - Only calls trip statistics methods if TRIP_STATISTICS is active - Reduces API overhead and prevents errors for unsupported services  This improves efficiency and aligns with the service discovery logic.
  
  Previously, the update() method called get_selectivestatus with a hardcoded list of services, regardless of whether they were discovered as active for the vehicle. This caused unnecessary API calls for services not available on the vehicle (e.g., TRIP_STATISTICS, FUEL_STATUS on ID. Series vehicles).
  
  Now the update() method:
  - Dynamically builds the service list based on discovered active services
  - Only calls get_parkingposition() if PARKING_POSITION is active
  - Only calls trip statistics methods if TRIP_STATISTICS is active
  - Reduces API overhead and prevents errors for unsupported services
  
  This improves efficiency and aligns with the service discovery logic.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
