### PR TITLE
fix: recover entities after HA reboot while car is offline (#940)

### DIFF
--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -148,7 +148,7 @@ def async_setup_platform_entities(
     def is_enabled(slug_attr: str) -> bool:
         return slug_attr in entry.options.get(CONF_RESOURCES, [slug_attr])
 
-    seen_attrs: set[str] = set()
+    seen_keys: set[tuple[str, str]] = set()
 
     def _add_new_entities() -> None:
         if coordinator.data is None:
@@ -157,11 +157,12 @@ def async_setup_platform_entities(
         for instrument in coordinator.data:
             if instrument.component != component:
                 continue
-            if instrument.attr in seen_attrs:
+            key = (instrument.component, instrument.attr)
+            if key in seen_keys:
                 continue
             if not is_enabled(instrument.slug_attr):
                 continue
-            seen_attrs.add(instrument.attr)
+            seen_keys.add(key)
             data.instruments.add(instrument)
             kwargs = dict(
                 data=data,

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -115,14 +115,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Return true if the resource is new."""
         return attr not in entry.options.get(CONF_AVAILABLE_RESOURCES, [attr])
 
-    components: set[str] = set()
     for instrument in (instr for instr in instruments if instr.component in COMPONENTS):
         # Add resource if enabled or new
-        if is_enabled(instrument.slug_attr) or (
-            is_new(instrument.slug_attr) and not entry.pref_disable_new_entities
-        ):
+        if is_enabled(instrument.slug_attr) or (is_new(instrument.slug_attr) and not entry.pref_disable_new_entities):
             data.instruments.add(instrument)
-            components.add(COMPONENTS[instrument.component])
 
     hass.data[DOMAIN][entry.entry_id] = {
         UPDATE_CALLBACK: update_callback,
@@ -130,10 +126,57 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UNDO_UPDATE_LISTENER: entry.add_update_listener(_async_update_listener),
     }
 
+    # Always set up all platforms so their coordinator listeners are registered
+    # even when the car is offline and some platforms have no current instruments.
+    components = list(COMPONENTS.values())
     coordinator.platforms.extend(components)
     await hass.config_entries.async_forward_entry_setups(entry, components)
 
     return True
+
+
+@callback
+def async_setup_platform_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: "VolkswagenCoordinator",
+    data: "VolkswagenData",
+    component: str,
+    entity_class,
+    async_add_entities,
+) -> None:
+    def is_enabled(slug_attr: str) -> bool:
+        return slug_attr in entry.options.get(CONF_RESOURCES, [slug_attr])
+
+    seen_attrs: set[str] = set()
+
+    def _add_new_entities() -> None:
+        if coordinator.data is None:
+            return
+        new_entities = []
+        for instrument in coordinator.data:
+            if instrument.component != component:
+                continue
+            if instrument.attr in seen_attrs:
+                continue
+            if not is_enabled(instrument.slug_attr):
+                continue
+            seen_attrs.add(instrument.attr)
+            data.instruments.add(instrument)
+            kwargs = dict(
+                data=data,
+                vin=coordinator.vin,
+                component=instrument.component,
+                attribute=instrument.attr,
+            )
+            if component != "lock" and component != "device_tracker":
+                kwargs["callback"] = hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK]
+            new_entities.append(entity_class(**kwargs))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -238,9 +281,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 class VolkswagenData:
     """Hold component state."""
 
-    def __init__(
-        self, config: dict[str, Any], coordinator: "VolkswagenCoordinator | None" = None
-    ) -> None:
+    def __init__(self, config: dict[str, Any], coordinator: "VolkswagenCoordinator | None" = None) -> None:
         """Initialize the component state."""
         self.vehicles: set[Vehicle] = set()
         self.instruments: set[Instrument] = set()
@@ -250,25 +291,19 @@ class VolkswagenData:
 
     def instrument(self, vin: str, component: str, attr: str) -> Instrument:
         """Return corresponding instrument."""
-        instruments = (
-            self.coordinator.data if self.coordinator is not None else self.instruments
-        )
+        instruments = self.coordinator.data if self.coordinator is not None else self.instruments
 
         instrument = next(
             (
                 instr
                 for instr in instruments
-                if instr.vehicle.vin == vin
-                and instr.component == component
-                and instr.attr == attr
+                if instr.vehicle.vin == vin and instr.component == component and instr.attr == attr
             ),
             None,
         )
 
         if instrument is None:
-            raise ValueError(
-                f"Instrument not found; component: {component}, attribute: {attr}, vin: {vin}"
-            )
+            raise ValueError(f"Instrument not found; component: {component}, attribute: {attr}, vin: {vin}")
 
         return instrument
 
@@ -359,9 +394,7 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
             return
 
         state_changed = str(self.state or STATE_UNKNOWN) != str(prev.state)
-        time_changed = str(prev.attributes.get("last_updated", None)) != str(
-            backend_refresh_time
-        )
+        time_changed = str(prev.attributes.get("last_updated", None)) != str(backend_refresh_time)
 
         # Check if custom attributes changed
         # Exclude system attributes that HA adds automatically
@@ -377,9 +410,7 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         }
         current_attrs = self.extra_state_attributes or {}
         prev_attrs = {k: v for k, v in prev.attributes.items() if k not in system_attrs}
-        current_attrs_compare = {
-            k: v for k, v in current_attrs.items() if k not in system_attrs
-        }
+        current_attrs_compare = {k: v for k, v in current_attrs.items() if k not in system_attrs}
         attributes_changed = current_attrs_compare != prev_attrs
 
         if time_changed or state_changed or attributes_changed:
@@ -411,31 +442,14 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         self.restored_state = await self.async_get_last_state()
 
         if self.coordinator is not None:
-            self.async_on_remove(
-                self.coordinator.async_add_listener(self.async_write_ha_state)
-            )
+            self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))
         else:
-            self.async_on_remove(
-                async_dispatcher_connect(
-                    self.hass, SIGNAL_STATE_UPDATED, self.async_write_ha_state
-                )
-            )
+            self.async_on_remove(async_dispatcher_connect(self.hass, SIGNAL_STATE_UPDATED, self.async_write_ha_state))
 
     @property
     def instrument(
         self,
-    ) -> (
-        BinarySensor
-        | Climate
-        | DoorLock
-        | Position
-        | Select
-        | Sensor
-        | Switch
-        | TrunkLock
-        | Number
-        | Instrument
-    ):
+    ) -> BinarySensor | Climate | DoorLock | Position | Select | Sensor | Switch | TrunkLock | Number | Instrument:
         """Return corresponding instrument."""
         return self.data.instrument(self.vin, self.component, self.attribute)
 
@@ -512,11 +526,7 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         try:
             # Check if instrument exists
             _ = self.instrument
-            return (
-                super().available
-                and self.coordinator.last_update_success
-                and self.instrument is not None
-            )
+            return super().available and self.coordinator.last_update_success and self.instrument is not None
         except ValueError:
             # Instrument not found (disabled or not supported)
             return False
@@ -537,9 +547,7 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
 class VolkswagenCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry, update_interval: timedelta
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, update_interval: timedelta) -> None:
         """Initialize the coordinator."""
         self.vin = entry.data[CONF_VEHICLE].upper()
         self.entry = entry
@@ -584,9 +592,7 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
 
         self.vehicle = vehicle
 
-        convert_conf = self.entry.options.get(
-            CONF_CONVERT, self.entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION)
-        )
+        convert_conf = self.entry.options.get(CONF_CONVERT, self.entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION))
 
         dashboard = vehicle.dashboard(
             mutable=self.entry.data.get(CONF_MUTABLE),

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -117,7 +117,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     for instrument in (instr for instr in instruments if instr.component in COMPONENTS):
         # Add resource if enabled or new
-        if is_enabled(instrument.slug_attr) or (is_new(instrument.slug_attr) and not entry.pref_disable_new_entities):
+        if is_enabled(instrument.slug_attr) or (
+            is_new(instrument.slug_attr) and not entry.pref_disable_new_entities
+        ):
             data.instruments.add(instrument)
 
     hass.data[DOMAIN][entry.entry_id] = {
@@ -282,7 +284,9 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 class VolkswagenData:
     """Hold component state."""
 
-    def __init__(self, config: dict[str, Any], coordinator: "VolkswagenCoordinator | None" = None) -> None:
+    def __init__(
+        self, config: dict[str, Any], coordinator: "VolkswagenCoordinator | None" = None
+    ) -> None:
         """Initialize the component state."""
         self.vehicles: set[Vehicle] = set()
         self.instruments: set[Instrument] = set()
@@ -292,19 +296,25 @@ class VolkswagenData:
 
     def instrument(self, vin: str, component: str, attr: str) -> Instrument:
         """Return corresponding instrument."""
-        instruments = self.coordinator.data if self.coordinator is not None else self.instruments
+        instruments = (
+            self.coordinator.data if self.coordinator is not None else self.instruments
+        )
 
         instrument = next(
             (
                 instr
                 for instr in instruments
-                if instr.vehicle.vin == vin and instr.component == component and instr.attr == attr
+                if instr.vehicle.vin == vin
+                and instr.component == component
+                and instr.attr == attr
             ),
             None,
         )
 
         if instrument is None:
-            raise ValueError(f"Instrument not found; component: {component}, attribute: {attr}, vin: {vin}")
+            raise ValueError(
+                f"Instrument not found; component: {component}, attribute: {attr}, vin: {vin}"
+            )
 
         return instrument
 
@@ -395,7 +405,9 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
             return
 
         state_changed = str(self.state or STATE_UNKNOWN) != str(prev.state)
-        time_changed = str(prev.attributes.get("last_updated", None)) != str(backend_refresh_time)
+        time_changed = str(prev.attributes.get("last_updated", None)) != str(
+            backend_refresh_time
+        )
 
         # Check if custom attributes changed
         # Exclude system attributes that HA adds automatically
@@ -411,7 +423,9 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         }
         current_attrs = self.extra_state_attributes or {}
         prev_attrs = {k: v for k, v in prev.attributes.items() if k not in system_attrs}
-        current_attrs_compare = {k: v for k, v in current_attrs.items() if k not in system_attrs}
+        current_attrs_compare = {
+            k: v for k, v in current_attrs.items() if k not in system_attrs
+        }
         attributes_changed = current_attrs_compare != prev_attrs
 
         if time_changed or state_changed or attributes_changed:
@@ -443,14 +457,31 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         self.restored_state = await self.async_get_last_state()
 
         if self.coordinator is not None:
-            self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))
+            self.async_on_remove(
+                self.coordinator.async_add_listener(self.async_write_ha_state)
+            )
         else:
-            self.async_on_remove(async_dispatcher_connect(self.hass, SIGNAL_STATE_UPDATED, self.async_write_ha_state))
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass, SIGNAL_STATE_UPDATED, self.async_write_ha_state
+                )
+            )
 
     @property
     def instrument(
         self,
-    ) -> BinarySensor | Climate | DoorLock | Position | Select | Sensor | Switch | TrunkLock | Number | Instrument:
+    ) -> (
+        BinarySensor
+        | Climate
+        | DoorLock
+        | Position
+        | Select
+        | Sensor
+        | Switch
+        | TrunkLock
+        | Number
+        | Instrument
+    ):
         """Return corresponding instrument."""
         return self.data.instrument(self.vin, self.component, self.attribute)
 
@@ -527,7 +558,11 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
         try:
             # Check if instrument exists
             _ = self.instrument
-            return super().available and self.coordinator.last_update_success and self.instrument is not None
+            return (
+                super().available
+                and self.coordinator.last_update_success
+                and self.instrument is not None
+            )
         except ValueError:
             # Instrument not found (disabled or not supported)
             return False
@@ -548,7 +583,9 @@ class VolkswagenEntity(CoordinatorEntity, RestoreEntity):
 class VolkswagenCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, update_interval: timedelta) -> None:
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, update_interval: timedelta
+    ) -> None:
         """Initialize the coordinator."""
         self.vin = entry.data[CONF_VEHICLE].upper()
         self.entry = entry
@@ -593,7 +630,9 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
 
         self.vehicle = vehicle
 
-        convert_conf = self.entry.options.get(CONF_CONVERT, self.entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION))
+        convert_conf = self.entry.options.get(
+            CONF_CONVERT, self.entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION)
+        )
 
         dashboard = vehicle.dashboard(
             mutable=self.entry.data.get(CONF_MUTABLE),

--- a/custom_components/volkswagencarnet/binary_sensor.py
+++ b/custom_components/volkswagencarnet/binary_sensor.py
@@ -10,8 +10,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
-from . import VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,22 +32,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the Volkswagen binary sensor."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenBinarySensor(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "binary_sensor"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "binary_sensor", VolkswagenBinarySensor, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/binary_sensor.py
+++ b/custom_components/volkswagencarnet/binary_sensor.py
@@ -33,7 +33,13 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
     async_setup_platform_entities(
-        hass, entry, coordinator, data, "binary_sensor", VolkswagenBinarySensor, async_add_devices
+        hass,
+        entry,
+        coordinator,
+        data,
+        "binary_sensor",
+        VolkswagenBinarySensor,
+        async_add_devices,
     )
     return True
 

--- a/custom_components/volkswagencarnet/climate.py
+++ b/custom_components/volkswagencarnet/climate.py
@@ -10,8 +10,8 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
-from . import VolkswagenData, VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenData, VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,22 +27,9 @@ async def async_setup_entry(hass, entry, async_add_devices):
     """Perform climate device setup."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenClimate(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "climate"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "climate", VolkswagenClimate, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/config_flow.py
+++ b/custom_components/volkswagencarnet/config_flow.py
@@ -339,7 +339,9 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
 
         vehicle: Vehicle = get_vehicle(coordinator=coordinator)
         instruments = vehicle.dashboard().instruments
-        current_instruments = {instrument.attr: instrument.name for instrument in instruments}
+        current_instruments = {
+            instrument.attr: instrument.name for instrument in instruments
+        }
         previously_available = data.get("options", {}).get(CONF_AVAILABLE_RESOURCES, {})
 
         if vehicle.is_connection_state_is_online_supported:

--- a/custom_components/volkswagencarnet/config_flow.py
+++ b/custom_components/volkswagencarnet/config_flow.py
@@ -50,9 +50,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_REGION, default=DEFAULT_REGION): str,
         vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
         vol.Optional(CONF_CONVERT, default=CONF_NO_CONVERSION): vol.In(CONVERT_DICT),
-        vol.Optional(
-            CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
-        ): cv.positive_int,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): cv.positive_int,
     }
 )
 
@@ -107,9 +105,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors["base"] = "cannot_connect"
             return
 
-        self.hass.async_create_task(
-            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
-        )
+        self.hass.async_create_task(self.hass.config_entries.flow.async_configure(flow_id=self.flow_id))
 
     async def async_step_login(self, user_input: dict | None = None) -> FlowResult:
         """Handle login step."""
@@ -136,15 +132,12 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.info("Found vehicle with VIN: %s", vehicle.vin)
 
         self._init_info["CONF_VEHICLES"] = {
-            vehicle.vin: vehicle.dashboard().instruments
-            for vehicle in self._connection.vehicles
+            vehicle.vin: vehicle.dashboard().instruments for vehicle in self._connection.vehicles
         }
 
         return self.async_show_progress_done(next_step_id="select_vehicle")
 
-    async def async_step_select_vehicle(
-        self, user_input: dict | None = None
-    ) -> FlowResult:
+    async def async_step_select_vehicle(self, user_input: dict | None = None) -> FlowResult:
         """Handle select vehicle step."""
         if user_input is not None:
             self._init_info[CONF_VEHICLE] = user_input[CONF_VEHICLE]
@@ -162,14 +155,10 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_VEHICLE): vol.In(vin_numbers)}),
         )
 
-    async def async_step_select_instruments(
-        self, user_input: dict | None = None
-    ) -> FlowResult:
+    async def async_step_select_instruments(self, user_input: dict | None = None) -> FlowResult:
         """Handle select instruments step."""
         instruments = self._init_info["CONF_VEHICLES"][self._init_info[CONF_VEHICLE]]
-        instruments_dict = {
-            instrument.attr: instrument.name for instrument in instruments
-        }
+        instruments_dict = {instrument.attr: instrument.name for instrument in instruments}
 
         if user_input is not None:
             self._init_info.pop("CONF_VEHICLES", None)
@@ -193,11 +182,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="select_instruments",
             errors=self._errors,
             data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_RESOURCES, default=list(instruments_dict.keys())
-                    ): cv.multi_select(instruments_dict)
-                }
+                {vol.Optional(CONF_RESOURCES, default=list(instruments_dict.keys())): cv.multi_select(instruments_dict)}
             ),
             last_step=True,
         )
@@ -208,9 +193,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._entry = self.hass.config_entries.async_get_entry(entry_id)
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(
-        self, user_input: dict | None = None
-    ) -> FlowResult:
+    async def async_step_reauth_confirm(self, user_input: dict | None = None) -> FlowResult:
         """Handle re-authentication with Volkswagen Connect."""
         errors: dict[str, str] = {}
 
@@ -221,9 +204,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 session=async_get_clientsession(self.hass),
                 username=user_input[CONF_USERNAME],
                 password=user_input[CONF_PASSWORD],
-                country=self._entry.options.get(
-                    CONF_REGION, self._entry.data[CONF_REGION]
-                ),
+                country=self._entry.options.get(CONF_REGION, self._entry.data[CONF_REGION]),
             )
 
             try:
@@ -257,9 +238,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_USERNAME, default=self._entry.data[CONF_USERNAME]
-                    ): str,
+                    vol.Required(CONF_USERNAME, default=self._entry.data[CONF_USERNAME]): str,
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
@@ -303,9 +282,7 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                     ): str,
                     vol.Optional(
                         CONF_REGION,
-                        default=self._config_entry.options.get(
-                            CONF_REGION, self._config_entry.data[CONF_REGION]
-                        ),
+                        default=self._config_entry.options.get(CONF_REGION, self._config_entry.data[CONF_REGION]),
                     ): str,
                     vol.Optional(
                         CONF_MUTABLE,
@@ -313,35 +290,40 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                     ): cv.boolean,
                     vol.Optional(
                         CONF_CONVERT,
-                        default=self._config_entry.data.get(
-                            CONF_CONVERT, CONF_NO_CONVERSION
-                        ),
+                        default=self._config_entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION),
                     ): vol.In(CONVERT_DICT),
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=self._config_entry.options.get(
                             CONF_SCAN_INTERVAL,
-                            self._config_entry.data.get(
-                                CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                            ),
+                            self._config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
                         ),
                     ): cv.positive_int,
                 }
             ),
         )
 
-    async def async_step_select_instruments(
-        self, user_input: dict | None = None
-    ) -> FlowResult:
+    async def async_step_select_instruments(self, user_input: dict | None = None) -> FlowResult:
         """Handle select instruments step."""
         coordinator = await get_coordinator(self.hass, self._config_entry)
         data = self._config_entry.as_dict()
 
         vehicle: Vehicle = get_vehicle(coordinator=coordinator)
         instruments = vehicle.dashboard().instruments
-        instruments_dict = {
-            instrument.attr: instrument.name for instrument in instruments
-        }
+        current_instruments = {instrument.attr: instrument.name for instrument in instruments}
+        previously_available = data.get("options", {}).get(CONF_AVAILABLE_RESOURCES, {})
+
+        if vehicle.is_connection_state_is_online_supported:
+            car_is_online = vehicle.connection_state_is_online
+        elif vehicle.is_connection_state_is_active_supported:
+            car_is_online = vehicle.connection_state_is_active
+        else:
+            car_is_online = False
+
+        if car_is_online:
+            instruments_dict = current_instruments
+        else:
+            instruments_dict = {**previously_available, **current_instruments}
 
         if user_input is not None:
             old_resources = set(data.get("options", {}).get(CONF_RESOURCES, []))
@@ -386,21 +368,13 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                 },
             )
 
-        selected = {
-            i
-            for i in instruments_dict
-            if i in data.get("options", {}).get(CONF_RESOURCES, [])
-        }
+        selected = {i for i in instruments_dict if i in data.get("options", {}).get(CONF_RESOURCES, [])}
 
         return self.async_show_form(
             step_id="select_instruments",
             errors=self._errors,
             data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_RESOURCES, default=list(selected)
-                    ): cv.multi_select(instruments_dict)
-                }
+                {vol.Optional(CONF_RESOURCES, default=list(selected)): cv.multi_select(instruments_dict)}
             ),
             last_step=True,
         )

--- a/custom_components/volkswagencarnet/config_flow.py
+++ b/custom_components/volkswagencarnet/config_flow.py
@@ -50,7 +50,9 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_REGION, default=DEFAULT_REGION): str,
         vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
         vol.Optional(CONF_CONVERT, default=CONF_NO_CONVERSION): vol.In(CONVERT_DICT),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): cv.positive_int,
+        vol.Optional(
+            CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+        ): cv.positive_int,
     }
 )
 
@@ -105,7 +107,9 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._errors["base"] = "cannot_connect"
             return
 
-        self.hass.async_create_task(self.hass.config_entries.flow.async_configure(flow_id=self.flow_id))
+        self.hass.async_create_task(
+            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+        )
 
     async def async_step_login(self, user_input: dict | None = None) -> FlowResult:
         """Handle login step."""
@@ -132,12 +136,15 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.info("Found vehicle with VIN: %s", vehicle.vin)
 
         self._init_info["CONF_VEHICLES"] = {
-            vehicle.vin: vehicle.dashboard().instruments for vehicle in self._connection.vehicles
+            vehicle.vin: vehicle.dashboard().instruments
+            for vehicle in self._connection.vehicles
         }
 
         return self.async_show_progress_done(next_step_id="select_vehicle")
 
-    async def async_step_select_vehicle(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_select_vehicle(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
         """Handle select vehicle step."""
         if user_input is not None:
             self._init_info[CONF_VEHICLE] = user_input[CONF_VEHICLE]
@@ -155,10 +162,14 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_VEHICLE): vol.In(vin_numbers)}),
         )
 
-    async def async_step_select_instruments(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_select_instruments(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
         """Handle select instruments step."""
         instruments = self._init_info["CONF_VEHICLES"][self._init_info[CONF_VEHICLE]]
-        instruments_dict = {instrument.attr: instrument.name for instrument in instruments}
+        instruments_dict = {
+            instrument.attr: instrument.name for instrument in instruments
+        }
 
         if user_input is not None:
             self._init_info.pop("CONF_VEHICLES", None)
@@ -182,7 +193,11 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="select_instruments",
             errors=self._errors,
             data_schema=vol.Schema(
-                {vol.Optional(CONF_RESOURCES, default=list(instruments_dict.keys())): cv.multi_select(instruments_dict)}
+                {
+                    vol.Optional(
+                        CONF_RESOURCES, default=list(instruments_dict.keys())
+                    ): cv.multi_select(instruments_dict)
+                }
             ),
             last_step=True,
         )
@@ -193,7 +208,9 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._entry = self.hass.config_entries.async_get_entry(entry_id)
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_reauth_confirm(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
         """Handle re-authentication with Volkswagen Connect."""
         errors: dict[str, str] = {}
 
@@ -204,7 +221,9 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 session=async_get_clientsession(self.hass),
                 username=user_input[CONF_USERNAME],
                 password=user_input[CONF_PASSWORD],
-                country=self._entry.options.get(CONF_REGION, self._entry.data[CONF_REGION]),
+                country=self._entry.options.get(
+                    CONF_REGION, self._entry.data[CONF_REGION]
+                ),
             )
 
             try:
@@ -238,7 +257,9 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME, default=self._entry.data[CONF_USERNAME]): str,
+                    vol.Required(
+                        CONF_USERNAME, default=self._entry.data[CONF_USERNAME]
+                    ): str,
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
@@ -282,7 +303,9 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                     ): str,
                     vol.Optional(
                         CONF_REGION,
-                        default=self._config_entry.options.get(CONF_REGION, self._config_entry.data[CONF_REGION]),
+                        default=self._config_entry.options.get(
+                            CONF_REGION, self._config_entry.data[CONF_REGION]
+                        ),
                     ): str,
                     vol.Optional(
                         CONF_MUTABLE,
@@ -290,20 +313,26 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                     ): cv.boolean,
                     vol.Optional(
                         CONF_CONVERT,
-                        default=self._config_entry.data.get(CONF_CONVERT, CONF_NO_CONVERSION),
+                        default=self._config_entry.data.get(
+                            CONF_CONVERT, CONF_NO_CONVERSION
+                        ),
                     ): vol.In(CONVERT_DICT),
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=self._config_entry.options.get(
                             CONF_SCAN_INTERVAL,
-                            self._config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+                            self._config_entry.data.get(
+                                CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                            ),
                         ),
                     ): cv.positive_int,
                 }
             ),
         )
 
-    async def async_step_select_instruments(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_select_instruments(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
         """Handle select instruments step."""
         coordinator = await get_coordinator(self.hass, self._config_entry)
         data = self._config_entry.as_dict()
@@ -368,13 +397,21 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                 },
             )
 
-        selected = {i for i in instruments_dict if i in data.get("options", {}).get(CONF_RESOURCES, [])}
+        selected = {
+            i
+            for i in instruments_dict
+            if i in data.get("options", {}).get(CONF_RESOURCES, [])
+        }
 
         return self.async_show_form(
             step_id="select_instruments",
             errors=self._errors,
             data_schema=vol.Schema(
-                {vol.Optional(CONF_RESOURCES, default=list(selected)): cv.multi_select(instruments_dict)}
+                {
+                    vol.Optional(
+                        CONF_RESOURCES, default=list(selected)
+                    ): cv.multi_select(instruments_dict)
+                }
             ),
             last_step=True,
         )

--- a/custom_components/volkswagencarnet/device_tracker.py
+++ b/custom_components/volkswagencarnet/device_tracker.py
@@ -19,7 +19,13 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
     async_setup_platform_entities(
-        hass, entry, coordinator, data, "device_tracker", VolkswagenDeviceTracker, async_add_devices
+        hass,
+        entry,
+        coordinator,
+        data,
+        "device_tracker",
+        VolkswagenDeviceTracker,
+        async_add_devices,
     )
     return True
 

--- a/custom_components/volkswagencarnet/device_tracker.py
+++ b/custom_components/volkswagencarnet/device_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
 
-from . import VolkswagenEntity
+from . import VolkswagenEntity, async_setup_platform_entities
 from .const import DATA, DATA_KEY, DOMAIN, SIGNAL_STATE_UPDATED
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,21 +18,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the Volkswagen device tracker."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenDeviceTracker(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "device_tracker"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "device_tracker", VolkswagenDeviceTracker, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/lock.py
+++ b/custom_components/volkswagencarnet/lock.py
@@ -5,7 +5,7 @@ import logging
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant
 
-from . import VolkswagenEntity
+from . import VolkswagenEntity, async_setup_platform_entities
 from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,21 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Perform entity setup."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenLock(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "lock"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "lock", VolkswagenLock, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/number.py
+++ b/custom_components/volkswagencarnet/number.py
@@ -9,8 +9,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import CONF_SCAN_INTERVAL
 
-from . import VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,22 +28,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the Volkswagen number."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenNumber(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "number"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "number", VolkswagenNumber, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/select.py
+++ b/custom_components/volkswagencarnet/select.py
@@ -6,8 +6,8 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
-from . import VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,22 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the Volkswagen select."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenSelect(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "select"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "select", VolkswagenSelect, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/sensor.py
+++ b/custom_components/volkswagencarnet/sensor.py
@@ -11,8 +11,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
-from . import VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,22 +30,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the entity."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenSensor(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "sensor"
-            )
-        )
-
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "sensor", VolkswagenSensor, async_add_devices
+    )
     return True
 
 

--- a/custom_components/volkswagencarnet/switch.py
+++ b/custom_components/volkswagencarnet/switch.py
@@ -6,8 +6,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
-from . import VolkswagenData, VolkswagenEntity
-from .const import DATA, DATA_KEY, DOMAIN, UPDATE_CALLBACK
+from . import VolkswagenData, VolkswagenEntity, async_setup_platform_entities
+from .const import DATA, DATA_KEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,21 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Add configured devices for this entity."""
     data = hass.data[DOMAIN][entry.entry_id][DATA]
     coordinator = data.coordinator
-    if coordinator.data is not None:
-        async_add_devices(
-            VolkswagenSwitch(
-                data=data,
-                vin=coordinator.vin,
-                component=instrument.component,
-                attribute=instrument.attr,
-                callback=hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
-            )
-            for instrument in (
-                instrument
-                for instrument in data.instruments
-                if instrument.component == "switch"
-            )
-        )
+    async_setup_platform_entities(
+        hass, entry, coordinator, data, "switch", VolkswagenSwitch, async_add_devices
+    )
     return True
 
 


### PR DESCRIPTION
Note: This fix was implemented using Claude
I'd recommend a proper sanity check before merging. The existing test
suite appears to be broken on master and could not be run.

Fixes #940

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Changes

- Platforms now register a coordinator listener so entities are created
  dynamically when they appear in coordinator data, rather than only at
  startup. New instruments not previously selected by the user are not
  added automatically.
- All platforms are always loaded at startup, regardless of how many
  instruments the current API response contains.
- The Configure flow now checks whether the car is online before building
  the instrument list. If online, the known list is updated from current
  data. If offline, the previously known list is preserved. This prevents
  permanent loss of the known instrument list when reconfiguring during
  an outage — not reported in #940 but discovered during analysis.