### PR TITLE
ci: tag-driven release workflow with pre-release detection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,36 +1,51 @@
 name: Release
 
 on:
-  release:
-    #types: [prereleased,published]
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  release_zip_file:
-    name: Prepare release asset
+  release:
+    name: Build and publish release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
-      - name: Get version
-        id: version
-        uses: home-assistant/actions/helpers/version@master
-
-      - name: "Update manifest.json"
+      - name: Detect pre-release
+        id: prerelease
         run: |
-          python3 ${{ github.workspace }}/manage/update_manifest.py --version ${{ steps.version.outputs.version }}
+          TAG="${GITHUB_REF_NAME}"
+          if echo "$TAG" | grep -qE '\-(rc|alpha|beta)\.?[0-9]+$'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Update manifest.json
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          python3 manage/update_manifest.py --version "$VERSION"
 
       - name: Create zip
         run: |
           cd custom_components/volkswagencarnet
           zip volkswagencarnet.zip -r ./
 
-      - name: Upload zip to release
-        uses: svenstaro/upload-release-action@2.11.3
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./custom_components/volkswagencarnet/volkswagencarnet.zip
-          asset_name: volkswagencarnet.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ./custom_components/volkswagencarnet/volkswagencarnet.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 __pycache__
 .DS_Store
+.planning/
+config/
+!config/configuration.yaml

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -18,9 +18,9 @@
 - [x] **NAL-02**: Config flow presents a country selector instead of the current region code field
 - [x] **NAL-03**: Country selection resolves to correct backend path (NA or EU) transparently
 - [x] **NAL-04**: All existing entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) work with NA vehicles
-- [ ] **NAL-05**: Existing EU users are not broken — migration path from current config to new country selector (validated via code review and tests, no EU credentials available)
+- [x] **NAL-05**: Existing EU users are not broken — migration path from current config to new country selector (validated via code review and tests, no EU credentials available)
 - [x] **NAL-06**: API rate limiting behavior is preserved (scan interval, 480 calls/day awareness)
-- [ ] **NAL-07**: Clear installation and setup instructions for HA admin users (HACS install, manual install, config flow walkthrough)
+- [x] **NAL-07**: Clear installation and setup instructions for HA admin users (HACS install, manual install, config flow walkthrough)
 
 ## v2 Requirements
 
@@ -52,9 +52,9 @@
 | NAL-02 | Phase 2 - NA Library Integration | Complete |
 | NAL-03 | Phase 2 - NA Library Integration | Complete |
 | NAL-04 | Phase 2 - NA Library Integration | Complete |
-| NAL-05 | Phase 2 - NA Library Integration | Pending |
+| NAL-05 | Phase 2 - NA Library Integration | Complete |
 | NAL-06 | Phase 2 - NA Library Integration | Complete |
-| NAL-07 | Phase 2 - NA Library Integration | Pending |
+| NAL-07 | Phase 2 - NA Library Integration | Complete |
 
 **Coverage:**
 - v1 requirements: 11 total

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -14,12 +14,12 @@
 
 ### NA Library Integration
 
-- [ ] **NAL-01**: Integration uses new library (drop-in replacement) that supports both NA and EU regions
-- [ ] **NAL-02**: Config flow presents a country selector instead of the current region code field
-- [ ] **NAL-03**: Country selection resolves to correct backend path (NA or EU) transparently
-- [ ] **NAL-04**: All existing entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) work with NA vehicles
+- [x] **NAL-01**: Integration uses new library (drop-in replacement) that supports both NA and EU regions
+- [x] **NAL-02**: Config flow presents a country selector instead of the current region code field
+- [x] **NAL-03**: Country selection resolves to correct backend path (NA or EU) transparently
+- [x] **NAL-04**: All existing entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) work with NA vehicles
 - [ ] **NAL-05**: Existing EU users are not broken — migration path from current config to new country selector (validated via code review and tests, no EU credentials available)
-- [ ] **NAL-06**: API rate limiting behavior is preserved (scan interval, 480 calls/day awareness)
+- [x] **NAL-06**: API rate limiting behavior is preserved (scan interval, 480 calls/day awareness)
 - [ ] **NAL-07**: Clear installation and setup instructions for HA admin users (HACS install, manual install, config flow walkthrough)
 
 ## v2 Requirements
@@ -48,12 +48,12 @@
 | DEV-02 | Phase 1 - Dev Environment | Complete |
 | DEV-03 | Phase 1 - Dev Environment | Complete |
 | DEV-04 | Phase 1 - Dev Environment | Complete |
-| NAL-01 | Phase 2 - NA Library Integration | Pending |
-| NAL-02 | Phase 2 - NA Library Integration | Pending |
-| NAL-03 | Phase 2 - NA Library Integration | Pending |
-| NAL-04 | Phase 2 - NA Library Integration | Pending |
+| NAL-01 | Phase 2 - NA Library Integration | Complete |
+| NAL-02 | Phase 2 - NA Library Integration | Complete |
+| NAL-03 | Phase 2 - NA Library Integration | Complete |
+| NAL-04 | Phase 2 - NA Library Integration | Complete |
 | NAL-05 | Phase 2 - NA Library Integration | Pending |
-| NAL-06 | Phase 2 - NA Library Integration | Pending |
+| NAL-06 | Phase 2 - NA Library Integration | Complete |
 | NAL-07 | Phase 2 - NA Library Integration | Pending |
 
 **Coverage:**

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,66 @@
+# Requirements: VW CarNet HA Integration — NA Expansion
+
+**Defined:** 2026-03-02
+**Core Value:** NA users can connect their VW vehicles to Home Assistant via a country-based config flow that routes to the correct backend library
+
+## v1 Requirements
+
+### Dev Environment
+
+- [x] **DEV-01**: Developer can build a Docker container running Home Assistant with the custom component loaded
+- [x] **DEV-02**: Developer can access HA UI (config flow, integrations page) from host browser
+- [x] **DEV-03**: Developer can modify integration source code and rebuild container to test changes
+- [x] **DEV-04**: Docker setup includes all dependencies (volkswagencarnet library, HA requirements)
+
+### NA Library Integration
+
+- [ ] **NAL-01**: Integration uses new library (drop-in replacement) that supports both NA and EU regions
+- [ ] **NAL-02**: Config flow presents a country selector instead of the current region code field
+- [ ] **NAL-03**: Country selection resolves to correct backend path (NA or EU) transparently
+- [ ] **NAL-04**: All existing entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) work with NA vehicles
+- [ ] **NAL-05**: Existing EU users are not broken — migration path from current config to new country selector (validated via code review and tests, no EU credentials available)
+- [ ] **NAL-06**: API rate limiting behavior is preserved (scan interval, 480 calls/day awareness)
+- [ ] **NAL-07**: Clear installation and setup instructions for HA admin users (HACS install, manual install, config flow walkthrough)
+
+## v2 Requirements
+
+### Testing & Quality
+
+- **TEST-01**: Automated tests cover country-to-backend routing logic
+- **TEST-02**: Config flow migration tests for region → country upgrade
+- **TEST-03**: Docker dev environment supports running pytest inside container
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| NYC Alternate Side Parking | Standalone integration, separate project |
+| Mock/stub VW API | Owner has real NA account, mocking adds complexity without value |
+| VS Code devcontainer | Simple Docker rebuild workflow preferred |
+| New entity types for NA-specific features | Same instruments as EU, drop-in replacement |
+| CI/CD pipeline changes | Focus on local dev and integration code |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| DEV-01 | Phase 1 - Dev Environment | Complete |
+| DEV-02 | Phase 1 - Dev Environment | Complete |
+| DEV-03 | Phase 1 - Dev Environment | Complete |
+| DEV-04 | Phase 1 - Dev Environment | Complete |
+| NAL-01 | Phase 2 - NA Library Integration | Pending |
+| NAL-02 | Phase 2 - NA Library Integration | Pending |
+| NAL-03 | Phase 2 - NA Library Integration | Pending |
+| NAL-04 | Phase 2 - NA Library Integration | Pending |
+| NAL-05 | Phase 2 - NA Library Integration | Pending |
+| NAL-06 | Phase 2 - NA Library Integration | Pending |
+| NAL-07 | Phase 2 - NA Library Integration | Pending |
+
+**Coverage:**
+- v1 requirements: 11 total
+- Mapped to phases: 11
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-03-02*
+*Last updated: 2026-03-02 after roadmap creation*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,59 @@
+# Roadmap: VW CarNet HA Integration — NA Expansion
+
+## Overview
+
+Two phases deliver the complete expansion: first, a containerized dev environment that makes iteration fast and reliable; then, the NA library integration that adds country-based backend routing so North American VW owners can use the same integration EU users already rely on.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [x] **Phase 1: Dev Environment** - Containerized HA instance with the integration pre-loaded for local testing (completed 2026-03-03)
+- [ ] **Phase 2: NA Library Integration** - Drop-in backend replacement with country selector and EU backward compatibility
+
+## Phase Details
+
+### Phase 1: Dev Environment
+**Goal**: Developer can build, run, and iterate on the integration in a local Docker container
+**Depends on**: Nothing (first phase)
+**Requirements**: DEV-01, DEV-02, DEV-03, DEV-04
+**Success Criteria** (what must be TRUE):
+  1. Developer runs a single command and gets a running HA instance with the integration loaded
+  2. Developer can open the HA UI in a host browser and reach the integrations config flow
+  3. Developer edits integration source code, rebuilds the container, and the change is reflected without manual file copying
+  4. Container environment includes all required dependencies (volkswagencarnet library and HA requirements) with no manual pip installs
+**Plans:** 1/1 plans complete
+
+Plans:
+- [ ] 01-01-PLAN.md — Docker dev environment: compose, entrypoint, watcher, config
+
+### Phase 2: NA Library Integration
+**Goal**: Users in North America can add the integration using a country picker that routes to the correct backend, while existing EU users continue working without reconfiguration
+**Depends on**: Phase 1
+**Requirements**: NAL-01, NAL-02, NAL-03, NAL-04, NAL-05, NAL-06, NAL-07
+**Success Criteria** (what must be TRUE):
+  1. Config flow shows a country selector and uses it to route to either the NA or EU backend library transparently
+  2. An NA VW account completes setup and exposes the same entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) as an EU account
+  3. An existing EU config entry upgrades to the new country-based format without requiring the user to reconfigure
+  4. Scan interval and 480-calls/day rate limiting behavior works identically for both NA and EU vehicles
+**Plans**: TBD
+
+Plans:
+- [ ] 02-01: Library swap — replace volkswagencarnet import with new drop-in library
+- [ ] 02-02: Country selector — config flow country picker wired to backend routing
+- [ ] 02-03: Migration — config entry upgrade from region code to country selector
+- [ ] 02-04: Documentation — installation and setup instructions for HA admin users
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Dev Environment | 1/1 | Complete   | 2026-03-03 |
+| 2. NA Library Integration | 0/4 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -40,7 +40,7 @@ Plans:
   2. An NA VW account completes setup and exposes the same entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) as an EU account
   3. An existing EU config entry upgrades to the new country-based format without requiring the user to reconfigure
   4. Scan interval and 480-calls/day rate limiting behavior works identically for both NA and EU vehicles
-**Plans:** 2 plans
+**Plans:** 1/2 plans executed
 
 Plans:
 - [ ] 02-01-PLAN.md — Library swap + country selector config flow (NAL-01, NAL-02, NAL-03, NAL-04, NAL-06)
@@ -54,4 +54,4 @@ Phases execute in numeric order: 1 → 2
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Dev Environment | 1/1 | Complete   | 2026-03-03 |
-| 2. NA Library Integration | 0/2 | Not started | - |
+| 2. NA Library Integration | 1/2 | In Progress|  |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -29,7 +29,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 **Plans:** 1/1 plans complete
 
 Plans:
-- [ ] 01-01-PLAN.md — Docker dev environment: compose, entrypoint, watcher, config
+- [x] 01-01-PLAN.md — Docker dev environment: compose, entrypoint, watcher, config
 
 ### Phase 2: NA Library Integration
 **Goal**: Users in North America can add the integration using a country picker that routes to the correct backend, while existing EU users continue working without reconfiguration
@@ -40,13 +40,11 @@ Plans:
   2. An NA VW account completes setup and exposes the same entity types (sensor, binary_sensor, lock, switch, climate, number, select, device_tracker) as an EU account
   3. An existing EU config entry upgrades to the new country-based format without requiring the user to reconfigure
   4. Scan interval and 480-calls/day rate limiting behavior works identically for both NA and EU vehicles
-**Plans**: TBD
+**Plans:** 2 plans
 
 Plans:
-- [ ] 02-01: Library swap — replace volkswagencarnet import with new drop-in library
-- [ ] 02-02: Country selector — config flow country picker wired to backend routing
-- [ ] 02-03: Migration — config entry upgrade from region code to country selector
-- [ ] 02-04: Documentation — installation and setup instructions for HA admin users
+- [ ] 02-01-PLAN.md — Library swap + country selector config flow (NAL-01, NAL-02, NAL-03, NAL-04, NAL-06)
+- [ ] 02-02-PLAN.md — Config entry migration, repairs flow, and documentation (NAL-05, NAL-07)
 
 ## Progress
 
@@ -56,4 +54,4 @@ Phases execute in numeric order: 1 → 2
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Dev Environment | 1/1 | Complete   | 2026-03-03 |
-| 2. NA Library Integration | 0/4 | Not started | - |
+| 2. NA Library Integration | 0/2 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: planning
-stopped_at: Completed 02-na-library-integration 02-01-PLAN.md
-last_updated: "2026-03-07T15:53:26.931Z"
+stopped_at: Completed 02-na-library-integration 02-02-PLAN.md
+last_updated: "2026-03-07T15:57:26.300Z"
 last_activity: 2026-03-02 — Roadmap created
 progress:
   total_phases: 2
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 3
-  completed_plans: 2
+  completed_plans: 3
   percent: 100
 ---
 
@@ -52,6 +52,7 @@ Progress: [██████████] 100%
 *Updated after each plan completion*
 | Phase 01-dev-environment P01 | 2 | 2 tasks | 5 files |
 | Phase 02-na-library-integration P01 | 2min | 2 tasks | 7 files |
+| Phase 02-na-library-integration P02 | 2 | 2 tasks | 5 files |
 
 ## Accumulated Context
 
@@ -68,6 +69,8 @@ Recent decisions affecting current work:
 - [Phase 02-na-library-integration]: Track forked volkswagencarnet via git URL (not PyPI) targeting main branch until stable release
 - [Phase 02-na-library-integration]: vol.Required(CONF_COUNTRY) with no default - user must explicitly pick country, no silent default
 - [Phase 02-na-library-integration]: VERSION bumped 3->4 to trigger async_migrate_entry for existing config entries; CONF_REGION kept for migration fallback in Plan 02-02
+- [Phase 02-na-library-integration]: Inline import of issue_registry inside v3->v4 block avoids module-level dependency
+- [Phase 02-na-library-integration]: HA Repairs framework used for post-migration country confirmation - user must confirm before integration reconnects
 
 ### Pending Todos
 
@@ -79,6 +82,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-07T15:53:26.924Z
-Stopped at: Completed 02-na-library-integration 02-01-PLAN.md
+Last session: 2026-03-07T15:57:26.295Z
+Stopped at: Completed 02-na-library-integration 02-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v1.0
 milestone_name: milestone
 status: planning
 stopped_at: Completed 02-na-library-integration 02-02-PLAN.md
-last_updated: "2026-03-07T15:57:26.300Z"
+last_updated: "2026-03-07T16:00:56.274Z"
 last_activity: 2026-03-02 — Roadmap created
 progress:
   total_phases: 2
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-03-02)
 Phase: 1 of 2 (Dev Environment)
 Plan: 0 of 1 in current phase
 Status: Ready to plan
-Last activity: 2026-03-02 — Roadmap created
+Last activity: 2026-03-18 - Completed quick task 2: Pull updated volkswagencarnet library (typed exceptions + force-reinstall)
 
 Progress: [██████████] 100%
 
@@ -80,8 +80,15 @@ None yet.
 
 - NA library repo not yet available — Phase 2 plan must account for the repo TBD state; integrate once available
 
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 1 | Fix IMPL-BUG-01 | 2026-03-07 | d5b8ec6 | [1-fix-impl-bug-01](./quick/1-fix-impl-bug-01/) |
+| 2 | Pull updated volkswagencarnet library (typed exceptions + force-reinstall) | 2026-03-18 | e9ad36c | [260317-uoc-pull-updated-volkswagencarnet-library-in](./quick/260317-uoc-pull-updated-volkswagencarnet-library-in/) |
+
 ## Session Continuity
 
-Last session: 2026-03-07T15:57:26.295Z
-Stopped at: Completed 02-na-library-integration 02-02-PLAN.md
+Last session: 2026-03-18T02:09:54Z
+Stopped at: Completed quick task 260317-uoc: Pull updated volkswagencarnet library
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: planning
-stopped_at: Completed 01-dev-environment-01-01-PLAN.md
-last_updated: "2026-03-03T17:39:52.288Z"
+stopped_at: Completed 02-na-library-integration 02-01-PLAN.md
+last_updated: "2026-03-07T15:53:26.931Z"
 last_activity: 2026-03-02 — Roadmap created
 progress:
   total_phases: 2
   completed_phases: 1
-  total_plans: 1
-  completed_plans: 1
+  total_plans: 3
+  completed_plans: 2
   percent: 100
 ---
 
@@ -51,6 +51,7 @@ Progress: [██████████] 100%
 
 *Updated after each plan completion*
 | Phase 01-dev-environment P01 | 2 | 2 tasks | 5 files |
+| Phase 02-na-library-integration P01 | 2min | 2 tasks | 7 files |
 
 ## Accumulated Context
 
@@ -64,6 +65,9 @@ Recent decisions affecting current work:
 - Docker container (not devcontainer) — simple rebuild-and-test workflow, no IDE coupling (pending)
 - [Phase 01-dev-environment]: Use ghcr.io/home-assistant/home-assistant:stable with volume mounts and pip-install entrypoint for VW CarNet dev environment
 - [Phase 01-dev-environment]: Host-side inotifywait watcher with polling flag and 2s debounce for cross-filesystem reliable auto-restart
+- [Phase 02-na-library-integration]: Track forked volkswagencarnet via git URL (not PyPI) targeting main branch until stable release
+- [Phase 02-na-library-integration]: vol.Required(CONF_COUNTRY) with no default - user must explicitly pick country, no silent default
+- [Phase 02-na-library-integration]: VERSION bumped 3->4 to trigger async_migrate_entry for existing config entries; CONF_REGION kept for migration fallback in Plan 02-02
 
 ### Pending Todos
 
@@ -75,6 +79,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-03-03T17:39:52.283Z
-Stopped at: Completed 01-dev-environment-01-01-PLAN.md
+Last session: 2026-03-07T15:53:26.924Z
+Stopped at: Completed 02-na-library-integration 02-01-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,80 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
+status: planning
+stopped_at: Completed 01-dev-environment-01-01-PLAN.md
+last_updated: "2026-03-03T17:39:52.288Z"
+last_activity: 2026-03-02 — Roadmap created
+progress:
+  total_phases: 2
+  completed_phases: 1
+  total_plans: 1
+  completed_plans: 1
+  percent: 100
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-03-02)
+
+**Core value:** NA users can connect their VW vehicles to Home Assistant via a country-based config flow that routes to the correct backend library
+**Current focus:** Phase 1 - Dev Environment
+
+## Current Position
+
+Phase: 1 of 2 (Dev Environment)
+Plan: 0 of 1 in current phase
+Status: Ready to plan
+Last activity: 2026-03-02 — Roadmap created
+
+Progress: [██████████] 100%
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 0
+- Average duration: -
+- Total execution time: 0 hours
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| - | - | - | - |
+
+**Recent Trend:**
+- Last 5 plans: -
+- Trend: -
+
+*Updated after each plan completion*
+| Phase 01-dev-environment P01 | 2 | 2 tasks | 5 files |
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- Country selector instead of region code — more intuitive UX, maps to NA/EU routing (pending)
+- New library replaces volkswagencarnet as drop-in — same API surface, supports both regions (pending)
+- Docker container (not devcontainer) — simple rebuild-and-test workflow, no IDE coupling (pending)
+- [Phase 01-dev-environment]: Use ghcr.io/home-assistant/home-assistant:stable with volume mounts and pip-install entrypoint for VW CarNet dev environment
+- [Phase 01-dev-environment]: Host-side inotifywait watcher with polling flag and 2s debounce for cross-filesystem reliable auto-restart
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- NA library repo not yet available — Phase 2 plan must account for the repo TBD state; integrate once available
+
+## Session Continuity
+
+Last session: 2026-03-03T17:39:52.283Z
+Stopped at: Completed 01-dev-environment-01-01-PLAN.md
+Resume file: None

--- a/.planning/phases/01-dev-environment/01-01-SUMMARY.md
+++ b/.planning/phases/01-dev-environment/01-01-SUMMARY.md
@@ -1,0 +1,126 @@
+---
+phase: 01-dev-environment
+plan: 01
+subsystem: infra
+tags: [docker, docker-compose, home-assistant, inotifywait, bash]
+
+# Dependency graph
+requires: []
+provides:
+  - Docker Compose dev environment with persistent and fresh profiles
+  - Entrypoint script that installs volkswagencarnet before launching HA
+  - Host-side file watcher that restarts HA container on .py changes
+  - Minimal HA configuration with debug logging for the integration
+affects:
+  - 02-na-library-integration
+
+# Tech tracking
+tech-stack:
+  added: [docker, docker-compose, inotifywait]
+  patterns:
+    - Volume-mount pattern for live code reload without container rebuild
+    - Entrypoint pip-install pattern for runtime dependency injection
+    - Host-side inotifywait watcher with polling fallback for cross-filesystem compatibility
+
+key-files:
+  created:
+    - dev/compose.yaml
+    - dev/entrypoint.sh
+    - dev/watch.sh
+    - config/configuration.yaml
+  modified:
+    - .gitignore
+
+key-decisions:
+  - "Use ghcr.io/home-assistant/home-assistant:stable (official image, always latest stable)"
+  - "Mount custom_components/ as volume — no COPY step, edits reflected immediately"
+  - "Entrypoint pip-installs requirements.txt at startup — ensures volkswagencarnet available even if HA manifest auto-install fails"
+  - "Host-side inotifywait watcher (not container-side) — inotify events don't propagate into containers"
+  - "config/ excluded from git, config/configuration.yaml force-tracked via !config/configuration.yaml gitignore negation"
+
+patterns-established:
+  - "Watcher pattern: inotifywait --polling on host, 2s debounce, docker restart"
+  - "Fresh profile pattern: named volume instead of host mount for clean-slate testing"
+
+requirements-completed: [DEV-01, DEV-02, DEV-03, DEV-04]
+
+# Metrics
+duration: 2min
+completed: 2026-03-03
+---
+
+# Phase 1 Plan 01: Dev Environment Summary
+
+**Docker Compose HA dev environment with inotifywait file watcher, pip-install entrypoint, and persistent/fresh profiles for edit-restart-test loop**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-03T17:36:48Z
+- **Completed:** 2026-03-03T17:38:43Z
+- **Tasks:** 2 of 2
+- **Files modified:** 5
+
+## Accomplishments
+
+- Docker Compose setup with default (persistent) and fresh (clean-slate) profiles for HA dev
+- Entrypoint script that pip-installs volkswagencarnet from requirements.txt before launching HA, preventing ModuleNotFoundError
+- Host-side file watcher using inotifywait with polling fallback and 2s debounce for reliable auto-restart
+- HA configuration with debug logging enabled for the integration from the start
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create Docker dev environment infrastructure** - `45e215b` (feat)
+2. **Task 2: Create file watcher script and validate Docker setup** - `47f0aaa` (feat)
+
+## Files Created/Modified
+
+- `dev/compose.yaml` - Docker Compose v2 with homeassistant (default) and homeassistant-fresh (fresh profile) services, named volume ha-fresh-config
+- `dev/entrypoint.sh` - Bash startup script: pip installs requirements.txt then execs python -m homeassistant
+- `dev/watch.sh` - Host-side watcher: inotifywait --polling on custom_components/, 2s debounce, docker restart ha-dev
+- `config/configuration.yaml` - Minimal HA config with debug logging for custom_components.volkswagencarnet and volkswagencarnet
+- `.gitignore` - Added config/ exclusion and !config/configuration.yaml negation to track only the minimal config
+
+## Decisions Made
+
+- Used `ghcr.io/home-assistant/home-assistant:stable` (the GitHub Container Registry image) as specified in the plan
+- Ran `git add -f config/configuration.yaml` because git won't stage files inside an ignored directory even with negation patterns — this is expected behavior and the file is correctly tracked in git history
+- `inotifywait --polling` flag used for cross-filesystem reliability (bind mounts, network filesystems, WSL2)
+- `docker compose config --quiet` validated both default and fresh profiles successfully
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+One minor implementation note: `git add -f` was required to force-track `config/configuration.yaml` because git ignores all files in `config/` before evaluating the `!config/configuration.yaml` negation pattern. This is expected git behavior and not a deviation from the plan's intent.
+
+## Issues Encountered
+
+None - all verification checks passed on first attempt.
+
+## User Setup Required
+
+None - no external service configuration required. Developer can run `docker compose up` from the `dev/` directory immediately.
+
+## Next Phase Readiness
+
+- Dev environment is fully operational: `cd dev && docker compose up` starts HA with the integration loaded
+- File watcher: `cd dev && ./watch.sh` on the host enables auto-restart on code changes
+- Fresh testing: `docker compose --profile fresh up` for clean HA config
+- Phase 2 (NA library integration) can proceed — the dev environment will load whatever integration code is mounted
+
+---
+*Phase: 01-dev-environment*
+*Completed: 2026-03-03*
+
+## Self-Check: PASSED
+
+- dev/compose.yaml: FOUND
+- dev/entrypoint.sh: FOUND
+- dev/watch.sh: FOUND
+- config/configuration.yaml: FOUND
+- 01-01-SUMMARY.md: FOUND
+- Commit 45e215b: FOUND
+- Commit 47f0aaa: FOUND

--- a/.planning/phases/02-na-library-integration/02-01-PLAN.md
+++ b/.planning/phases/02-na-library-integration/02-01-PLAN.md
@@ -1,0 +1,283 @@
+---
+phase: 02-na-library-integration
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - requirements.txt
+  - custom_components/volkswagencarnet/manifest.json
+  - custom_components/volkswagencarnet/const.py
+  - custom_components/volkswagencarnet/config_flow.py
+  - custom_components/volkswagencarnet/__init__.py
+  - custom_components/volkswagencarnet/strings.json
+  - custom_components/volkswagencarnet/translations/en.json
+autonomous: true
+requirements: [NAL-01, NAL-02, NAL-03, NAL-04, NAL-06]
+
+must_haves:
+  truths:
+    - "New config flow shows a country dropdown with ~15 VW-market countries plus 'Other'"
+    - "Selecting a country and providing credentials completes the setup flow"
+    - "Country value is passed to Connection(country=...) for both new setups and coordinator"
+    - "Options flow shows the same country dropdown instead of free-text region field"
+    - "Reauth flow reads CONF_COUNTRY from config entry data"
+    - "No entity platform files are modified (drop-in library, same API surface)"
+    - "Rate limiting behavior is unchanged (scan interval logic untouched)"
+  artifacts:
+    - path: "requirements.txt"
+      provides: "Forked library git URL dependency"
+      contains: "git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main"
+    - path: "custom_components/volkswagencarnet/manifest.json"
+      provides: "HA auto-install requirement"
+      contains: "git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main"
+    - path: "custom_components/volkswagencarnet/const.py"
+      provides: "CONF_COUNTRY, COUNTRY_LIST, CONF_COUNTRY_CUSTOM constants"
+      exports: ["CONF_COUNTRY", "COUNTRY_LIST", "CONF_COUNTRY_CUSTOM"]
+    - path: "custom_components/volkswagencarnet/config_flow.py"
+      provides: "Country dropdown in DATA_SCHEMA, options flow, reauth flow"
+      contains: "vol.In(COUNTRY_LIST)"
+    - path: "custom_components/volkswagencarnet/__init__.py"
+      provides: "Coordinator reads CONF_COUNTRY instead of CONF_REGION"
+      contains: "CONF_COUNTRY"
+  key_links:
+    - from: "custom_components/volkswagencarnet/config_flow.py"
+      to: "volkswagencarnet.vw_connection.Connection"
+      via: "country=self._init_info[CONF_COUNTRY]"
+      pattern: "country=.*CONF_COUNTRY"
+    - from: "custom_components/volkswagencarnet/__init__.py"
+      to: "volkswagencarnet.vw_connection.Connection"
+      via: "country=entry.data[CONF_COUNTRY]"
+      pattern: "country=.*CONF_COUNTRY"
+    - from: "custom_components/volkswagencarnet/config_flow.py"
+      to: "custom_components/volkswagencarnet/const.py"
+      via: "imports CONF_COUNTRY, COUNTRY_LIST, CONF_COUNTRY_CUSTOM"
+      pattern: "from .const import.*CONF_COUNTRY"
+---
+
+<objective>
+Replace the upstream volkswagencarnet library with the forked drop-in that supports NA+EU, and update the config flow from a free-text region field to a country dropdown with "Other" escape hatch.
+
+Purpose: This is the core functional change -- after this plan, a new user in the US or Canada can set up the integration by picking their country from a dropdown and the library routes to the correct NA backend transparently. EU users picking DE/NL/etc. continue working identically.
+
+Output: Updated dependency, constants, config flow (setup + options + reauth), coordinator Connection creation, and UI strings.
+</objective>
+
+<execution_context>
+@/home/pascal/.claude/get-shit-done/workflows/execute-plan.md
+@/home/pascal/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-na-library-integration/02-CONTEXT.md
+@.planning/phases/02-na-library-integration/02-RESEARCH.md
+
+@custom_components/volkswagencarnet/const.py
+@custom_components/volkswagencarnet/config_flow.py
+@custom_components/volkswagencarnet/__init__.py
+@custom_components/volkswagencarnet/manifest.json
+@custom_components/volkswagencarnet/strings.json
+@custom_components/volkswagencarnet/translations/en.json
+@requirements.txt
+
+<interfaces>
+<!-- Key types and contracts the executor needs. Extracted from codebase. -->
+
+From custom_components/volkswagencarnet/const.py (current):
+```python
+CONF_REGION = "region"      # Will be kept for migration read-out
+DEFAULT_REGION = "DE"       # Will be kept for migration default
+CONVERT_DICT = {...}        # Pattern to follow for COUNTRY_LIST (vol.In dict)
+```
+
+From custom_components/volkswagencarnet/config_flow.py (current):
+```python
+# Line 50: vol.Optional(CONF_REGION, default=DEFAULT_REGION): str,  -- becomes vol.Required(CONF_COUNTRY): vol.In(COUNTRY_LIST)
+# Line 63: VERSION = 3  -- becomes VERSION = 4
+# Line 85: country=self._init_info[CONF_REGION],  -- becomes CONF_COUNTRY (with OTHER collapse logic)
+# Lines 224-226: country=self._entry.options.get(CONF_REGION, self._entry.data[CONF_REGION]),  -- becomes CONF_COUNTRY
+# Lines 304-309: Options flow CONF_REGION free-text  -- becomes vol.In(COUNTRY_LIST) dropdown
+```
+
+From custom_components/volkswagencarnet/__init__.py (current):
+```python
+# Line 552: country=self.entry.options.get(CONF_REGION, self.entry.data[CONF_REGION]),  -- becomes CONF_COUNTRY
+# Line 52: from .const import ... CONF_REGION ...  -- add CONF_COUNTRY import
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Swap library dependency and define country constants</name>
+  <files>requirements.txt, custom_components/volkswagencarnet/manifest.json, custom_components/volkswagencarnet/const.py</files>
+  <action>
+1. **requirements.txt**: Replace `volkswagencarnet==5.4.5` with `volkswagencarnet @ git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main` (per user decision -- git URL, track main branch, no PyPI).
+
+2. **manifest.json**: Set the `requirements` array to `["volkswagencarnet @ git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main"]`. Do NOT run manage/update_manifest.py -- edit manifest.json directly to ensure the git URL format is correct.
+
+3. **const.py**: Add the following constants (keep CONF_REGION and DEFAULT_REGION for migration read-out in Plan 02):
+
+```python
+CONF_COUNTRY = "country"
+CONF_COUNTRY_CUSTOM = "country_custom"
+DEFAULT_COUNTRY = "DE"  # Used only as migration fallback
+
+COUNTRY_LIST = {
+    "US": "United States",
+    "CA": "Canada",
+    "DE": "Germany",
+    "GB": "United Kingdom",
+    "NL": "Netherlands",
+    "SE": "Sweden",
+    "NO": "Norway",
+    "FR": "France",
+    "IT": "Italy",
+    "ES": "Spain",
+    "AT": "Austria",
+    "CH": "Switzerland",
+    "DK": "Denmark",
+    "FI": "Finland",
+    "BE": "Belgium",
+    "OTHER": "Other (enter country code below)",
+}
+```
+
+Place these after the existing `DEFAULT_REGION` line. Keep all existing constants unchanged.
+  </action>
+  <verify>
+    <automated>grep -q "git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main" requirements.txt && grep -q "git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main" custom_components/volkswagencarnet/manifest.json && python3 -c "exec(open('custom_components/volkswagencarnet/const.py').read()); assert 'US' in COUNTRY_LIST; assert CONF_COUNTRY == 'country'; assert CONF_COUNTRY_CUSTOM == 'country_custom'; print('OK')"</automated>
+  </verify>
+  <done>requirements.txt has forked git URL, manifest.json requirements array has git URL, const.py exports CONF_COUNTRY, CONF_COUNTRY_CUSTOM, DEFAULT_COUNTRY, and COUNTRY_LIST with 15 countries + OTHER</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update config flow, coordinator, and UI strings for country selector</name>
+  <files>custom_components/volkswagencarnet/config_flow.py, custom_components/volkswagencarnet/__init__.py, custom_components/volkswagencarnet/strings.json, custom_components/volkswagencarnet/translations/en.json</files>
+  <action>
+**config_flow.py changes:**
+
+1. **Imports**: Add `CONF_COUNTRY`, `CONF_COUNTRY_CUSTOM`, `COUNTRY_LIST`, `DEFAULT_COUNTRY` to the import from `.const`. Keep `CONF_REGION` import (needed for migration read in Plan 02 and reauth fallback).
+
+2. **DATA_SCHEMA** (line 44-57): Replace the `vol.Optional(CONF_REGION, default=DEFAULT_REGION): str` line with:
+   ```python
+   vol.Required(CONF_COUNTRY): vol.In(COUNTRY_LIST),
+   vol.Optional(CONF_COUNTRY_CUSTOM, default=""): str,
+   ```
+   Note: `vol.Required` with NO default -- user must explicitly pick (per user decision).
+
+3. **VERSION** (line 63): Change `VERSION = 3` to `VERSION = 4`.
+
+4. **async_step_user** (line 73-88): After `self._init_info = user_input` (line 77), add "Other" collapse logic before creating Connection:
+   ```python
+   # Collapse "Other" free-text into CONF_COUNTRY
+   if self._init_info.get(CONF_COUNTRY) == "OTHER":
+       custom_code = self._init_info.pop(CONF_COUNTRY_CUSTOM, "").strip().upper()
+       if len(custom_code) != 2:
+           self._errors[CONF_COUNTRY_CUSTOM] = "invalid_country_code"
+           return self.async_show_form(
+               step_id="user", data_schema=DATA_SCHEMA, errors=self._errors
+           )
+       self._init_info[CONF_COUNTRY] = custom_code
+   self._init_info.pop(CONF_COUNTRY_CUSTOM, None)  # Don't store in config entry
+   ```
+   Then change line 85 from `country=self._init_info[CONF_REGION]` to `country=self._init_info[CONF_COUNTRY]`.
+
+5. **async_step_reauth_confirm** (lines 224-226): Change from:
+   ```python
+   country=self._entry.options.get(CONF_REGION, self._entry.data[CONF_REGION]),
+   ```
+   to:
+   ```python
+   country=self._entry.data.get(CONF_COUNTRY, self._entry.data.get(CONF_REGION, DEFAULT_COUNTRY)),
+   ```
+   This handles both v4 entries (CONF_COUNTRY) and pre-migration v3 entries (CONF_REGION fallback).
+
+6. **Options flow async_step_user** (lines 296-331): Replace the `CONF_REGION` free-text field (lines 304-309) with:
+   ```python
+   vol.Optional(
+       CONF_COUNTRY,
+       default=self._config_entry.data.get(
+           CONF_COUNTRY, self._config_entry.data.get(CONF_REGION, DEFAULT_COUNTRY)
+       ),
+   ): vol.In(COUNTRY_LIST),
+   ```
+   Remove the old `CONF_REGION` field entirely from the options schema.
+
+**__init__.py changes:**
+
+7. **Imports** (line 45-63): Add `CONF_COUNTRY` and `DEFAULT_COUNTRY` to the import from `.const`. Keep `CONF_REGION` import (used in migration).
+
+8. **VolkswagenCoordinator.__init__** (line 548-553): Change:
+   ```python
+   country=self.entry.options.get(CONF_REGION, self.entry.data[CONF_REGION]),
+   ```
+   to:
+   ```python
+   country=self.entry.data.get(CONF_COUNTRY, self.entry.data.get(CONF_REGION, DEFAULT_COUNTRY)),
+   ```
+   This handles both v4 (CONF_COUNTRY) and pre-migration v3 (CONF_REGION) entries gracefully.
+
+**strings.json changes:**
+
+9. In `config.step.user.data`: Remove `"region"` and `"debug"` keys. Add:
+   ```json
+   "country": "Country where your car was sold",
+   "country_custom": "Custom country code (ISO 3166-1 alpha-2, only if 'Other' selected above)"
+   ```
+
+10. In `options.step.user.data`: Remove `"region"` key. Add:
+    ```json
+    "country": "Country where your car was sold"
+    ```
+
+11. In `config.error`: Add:
+    ```json
+    "invalid_country_code": "Please enter a valid 2-letter country code (e.g. US, DE, NL)"
+    ```
+
+**translations/en.json changes:**
+
+12. Mirror the exact same changes as strings.json: replace `region`/`debug` with `country`/`country_custom` in config step, replace `region` with `country` in options step, add the `invalid_country_code` error.
+
+**Important anti-patterns to avoid:**
+- Do NOT set a default value on `vol.Required(CONF_COUNTRY)` -- per user decision, no default.
+- Do NOT remove `CONF_REGION` from const.py imports -- it is needed for migration fallback reads in both this plan and Plan 02.
+- Do NOT modify any entity platform files (sensor.py, binary_sensor.py, etc.) -- the library is drop-in, same API surface (NAL-04).
+- Do NOT change scan interval logic -- rate limiting is preserved as-is (NAL-06).
+  </action>
+  <verify>
+    <automated>grep -q "CONF_COUNTRY" custom_components/volkswagencarnet/config_flow.py && grep -q "vol.In(COUNTRY_LIST)" custom_components/volkswagencarnet/config_flow.py && grep -q "VERSION = 4" custom_components/volkswagencarnet/config_flow.py && grep -q "CONF_COUNTRY" custom_components/volkswagencarnet/__init__.py && python3 -c "import json; d=json.load(open('custom_components/volkswagencarnet/strings.json')); assert 'country' in d['config']['step']['user']['data']; assert 'region' not in d['config']['step']['user']['data']; print('strings OK')" && python3 -c "import json; d=json.load(open('custom_components/volkswagencarnet/translations/en.json')); assert 'country' in d['config']['step']['user']['data']; assert 'region' not in d['config']['step']['user']['data']; print('en.json OK')"</automated>
+  </verify>
+  <done>Config flow DATA_SCHEMA uses vol.Required(CONF_COUNTRY) with vol.In(COUNTRY_LIST) dropdown and no default. VERSION=4. "Other" selection collapses to the custom 2-char code before storing. Options flow uses country dropdown. Reauth reads CONF_COUNTRY with CONF_REGION fallback. Coordinator reads CONF_COUNTRY with CONF_REGION fallback. strings.json and en.json updated with country labels and invalid_country_code error. No entity platform files modified.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `grep -c "CONF_REGION" custom_components/volkswagencarnet/config_flow.py` -- CONF_REGION should only appear in import line and reauth fallback, NOT in DATA_SCHEMA or options schema.
+2. `grep "CONF_COUNTRY" custom_components/volkswagencarnet/config_flow.py` shows usage in DATA_SCHEMA, async_step_user, reauth, and options flow.
+3. `grep "CONF_COUNTRY" custom_components/volkswagencarnet/__init__.py` shows usage in coordinator Connection creation.
+4. No changes to sensor.py, binary_sensor.py, lock.py, switch.py, climate.py, number.py, select.py, device_tracker.py.
+</verification>
+
+<success_criteria>
+- requirements.txt and manifest.json reference the forked library via git URL
+- const.py defines CONF_COUNTRY, CONF_COUNTRY_CUSTOM, DEFAULT_COUNTRY, COUNTRY_LIST (15 countries + OTHER)
+- Config flow VERSION = 4
+- DATA_SCHEMA has vol.Required(CONF_COUNTRY) with vol.In(COUNTRY_LIST) and no default
+- "Other" collapses to custom code before storing in config entry
+- Options flow shows country dropdown instead of free-text region
+- Reauth flow reads CONF_COUNTRY with CONF_REGION fallback
+- Coordinator Connection uses CONF_COUNTRY with CONF_REGION fallback
+- strings.json and en.json updated to match new field names
+- Zero entity platform file modifications
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-na-library-integration/02-01-SUMMARY.md`
+</output>

--- a/.planning/phases/02-na-library-integration/02-01-SUMMARY.md
+++ b/.planning/phases/02-na-library-integration/02-01-SUMMARY.md
@@ -1,0 +1,133 @@
+---
+phase: 02-na-library-integration
+plan: 01
+subsystem: config
+tags: [volkswagencarnet, home-assistant, config-flow, na-library, country-selector]
+
+# Dependency graph
+requires:
+  - phase: 01-dev-environment
+    provides: Dev environment for running HA with the integration
+provides:
+  - Forked NA-capable volkswagencarnet library as the integration's dependency
+  - Country dropdown config flow (15 VW-market countries + Other escape hatch)
+  - CONF_COUNTRY / COUNTRY_LIST constants for use by migration plan (02-02)
+  - VERSION=4 config entry schema
+affects:
+  - 02-02-migration (reads CONF_REGION fallback established here)
+
+# Tech tracking
+tech-stack:
+  added:
+    - volkswagencarnet @ git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main (forked library with NA+EU support)
+  patterns:
+    - CONF_COUNTRY with CONF_REGION fallback for backward compat in coordinator and reauth
+    - vol.In(COUNTRY_LIST) dropdown with Other + custom-code escape hatch
+    - Collapse "OTHER" to raw 2-char code before storing in config entry
+
+key-files:
+  created: []
+  modified:
+    - requirements.txt
+    - custom_components/volkswagencarnet/manifest.json
+    - custom_components/volkswagencarnet/const.py
+    - custom_components/volkswagencarnet/config_flow.py
+    - custom_components/volkswagencarnet/__init__.py
+    - custom_components/volkswagencarnet/strings.json
+    - custom_components/volkswagencarnet/translations/en.json
+
+key-decisions:
+  - "Track forked library via git URL (not PyPI) — targets main branch until stable release"
+  - "vol.Required(CONF_COUNTRY) with no default — user must explicitly pick country"
+  - "CONF_REGION kept in imports for migration fallback reads in Plan 02-02"
+  - "VERSION bumped 3->4 to trigger async_migrate_entry for existing entries"
+  - "Other collapse: store cleaned 2-char code in CONF_COUNTRY, never store country_custom in config entry"
+
+patterns-established:
+  - "Country selector pattern: vol.In(COUNTRY_LIST) with OTHER + free-text collapse"
+  - "Backward compat pattern: data.get(CONF_COUNTRY, data.get(CONF_REGION, DEFAULT_COUNTRY))"
+
+requirements-completed: [NAL-01, NAL-02, NAL-03, NAL-04, NAL-06]
+
+# Metrics
+duration: 2min
+completed: 2026-03-07
+---
+
+# Phase 2 Plan 1: NA Library Integration - Country Dropdown Config Flow Summary
+
+**Swapped volkswagencarnet to forked NA-capable git library and replaced free-text region field with a 15-country dropdown (US/CA/DE/etc.) with Other escape hatch, VERSION bumped to 4**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-07T15:49:57Z
+- **Completed:** 2026-03-07T15:52:13Z
+- **Tasks:** 2
+- **Files modified:** 7
+
+## Accomplishments
+
+- Replaced `volkswagencarnet==5.4.5` with forked git URL in both `requirements.txt` and `manifest.json` for HA auto-install
+- Added `CONF_COUNTRY`, `CONF_COUNTRY_CUSTOM`, `DEFAULT_COUNTRY`, and `COUNTRY_LIST` (15 countries + OTHER) to `const.py`
+- Updated config flow DATA_SCHEMA to `vol.Required(CONF_COUNTRY): vol.In(COUNTRY_LIST)` with Optional `CONF_COUNTRY_CUSTOM` for the Other path
+- Bumped `VERSION = 4`, added Other-collapse logic (validates 2-char ISO code, stores clean code, strips `country_custom` before saving to config entry)
+- Updated reauth and coordinator `Connection()` calls to use `CONF_COUNTRY` with `CONF_REGION` fallback for pre-migration entries
+- Replaced `CONF_REGION` free-text in options flow with `CONF_COUNTRY` dropdown using same fallback logic
+- Updated `strings.json` and `translations/en.json`: replaced `region`/`debug` keys with `country`/`country_custom`, added `invalid_country_code` error
+- Zero entity platform files modified — drop-in library with same API surface
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Swap library dependency and define country constants** - `8ec8344` (feat)
+2. **Task 2: Update config flow, coordinator, and UI strings for country selector** - `f153b0c` (feat)
+
+## Files Created/Modified
+
+- `requirements.txt` - Changed from `volkswagencarnet==5.4.5` to git URL of forked library
+- `custom_components/volkswagencarnet/manifest.json` - Set requirements array to forked git URL for HA auto-install
+- `custom_components/volkswagencarnet/const.py` - Added CONF_COUNTRY, CONF_COUNTRY_CUSTOM, DEFAULT_COUNTRY, COUNTRY_LIST (16 entries including OTHER)
+- `custom_components/volkswagencarnet/config_flow.py` - Country dropdown in DATA_SCHEMA, Other collapse logic, VERSION=4, updated reauth and options flow
+- `custom_components/volkswagencarnet/__init__.py` - Coordinator Connection now uses CONF_COUNTRY with CONF_REGION fallback
+- `custom_components/volkswagencarnet/strings.json` - country/country_custom fields, invalid_country_code error, removed region/debug
+- `custom_components/volkswagencarnet/translations/en.json` - Same changes mirrored from strings.json
+
+## Decisions Made
+
+- Track forked library via git URL (not PyPI) — user decision to target main branch until stable release on PyPI
+- `vol.Required(CONF_COUNTRY)` with no default — user must explicitly pick, no silent default country
+- `CONF_REGION` kept in imports for backward compat fallback; migration in Plan 02-02 will handle full conversion
+- VERSION bumped 3->4 to signal schema change and trigger migration handler for existing installs
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required. The forked library will be auto-installed by Home Assistant when the integration loads.
+
+## Next Phase Readiness
+
+- Config flow accepts country selection and passes it to `Connection(country=...)` for both NA and EU routing
+- Existing config entries (VERSION 3, CONF_REGION) will still work via fallback logic until migration in Plan 02-02
+- Plan 02-02 can now implement `async_migrate_entry` to upgrade v3 entries: map CONF_REGION value to CONF_COUNTRY, bump version to 4
+
+## Self-Check: PASSED
+
+- FOUND: const.py
+- FOUND: config_flow.py
+- FOUND: __init__.py
+- FOUND: 02-01-SUMMARY.md
+- FOUND commit: 8ec8344 (Task 1)
+- FOUND commit: f153b0c (Task 2)
+
+---
+*Phase: 02-na-library-integration*
+*Completed: 2026-03-07*

--- a/.planning/phases/02-na-library-integration/02-02-PLAN.md
+++ b/.planning/phases/02-na-library-integration/02-02-PLAN.md
@@ -1,0 +1,352 @@
+---
+phase: 02-na-library-integration
+plan: 02
+type: execute
+wave: 2
+depends_on: ["02-01"]
+files_modified:
+  - custom_components/volkswagencarnet/__init__.py
+  - custom_components/volkswagencarnet/repairs.py
+  - custom_components/volkswagencarnet/strings.json
+  - custom_components/volkswagencarnet/translations/en.json
+  - README.md
+autonomous: true
+requirements: [NAL-05, NAL-07]
+
+must_haves:
+  truths:
+    - "Existing EU config entry at version 3 auto-migrates to version 4 on HA startup"
+    - "Migration renames CONF_REGION to CONF_COUNTRY in both entry.data and entry.options"
+    - "A repair notification appears after migration asking user to confirm their country"
+    - "Clicking 'Fix' in Repairs UI shows a dropdown pre-populated with the existing country value"
+    - "After confirming country, the integration reloads and connects successfully"
+    - "README contains NA setup instructions explaining the country picker"
+  artifacts:
+    - path: "custom_components/volkswagencarnet/__init__.py"
+      provides: "v3->v4 migration block in async_migrate_entry"
+      contains: "version == 3"
+    - path: "custom_components/volkswagencarnet/repairs.py"
+      provides: "ConfirmCountryRepairFlow for interactive country confirmation"
+      exports: ["async_create_fix_flow"]
+    - path: "custom_components/volkswagencarnet/strings.json"
+      provides: "Repair issue strings (title, fix_flow steps)"
+      contains: "confirm_country"
+    - path: "README.md"
+      provides: "NA setup documentation section"
+      contains: "North America"
+  key_links:
+    - from: "custom_components/volkswagencarnet/__init__.py"
+      to: "homeassistant.helpers.issue_registry"
+      via: "ir.async_create_issue() in migration"
+      pattern: "async_create_issue"
+    - from: "custom_components/volkswagencarnet/repairs.py"
+      to: "custom_components/volkswagencarnet/const.py"
+      via: "imports CONF_COUNTRY, COUNTRY_LIST, DOMAIN"
+      pattern: "from .const import.*CONF_COUNTRY"
+    - from: "custom_components/volkswagencarnet/__init__.py"
+      to: "custom_components/volkswagencarnet/repairs.py"
+      via: "HA Repairs framework calls async_create_fix_flow when user clicks Fix"
+      pattern: "async_create_fix_flow"
+---
+
+<objective>
+Add config entry migration from version 3 to 4 with HA Repairs confirmation flow, and update README with NA setup instructions.
+
+Purpose: Existing EU users upgrading the integration need a safe migration path that preserves their country setting and asks them to confirm it. New NA users need clear setup instructions. This plan completes the upgrade story and documentation.
+
+Output: Migration logic in __init__.py, new repairs.py file, repair UI strings, and updated README.md.
+</objective>
+
+<execution_context>
+@/home/pascal/.claude/get-shit-done/workflows/execute-plan.md
+@/home/pascal/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-na-library-integration/02-CONTEXT.md
+@.planning/phases/02-na-library-integration/02-RESEARCH.md
+@.planning/phases/02-na-library-integration/02-01-SUMMARY.md
+
+@custom_components/volkswagencarnet/__init__.py
+@custom_components/volkswagencarnet/strings.json
+@custom_components/volkswagencarnet/translations/en.json
+@README.md
+
+<interfaces>
+<!-- Key types and contracts from Plan 01. Executor needs these. -->
+
+From custom_components/volkswagencarnet/const.py (after Plan 01):
+```python
+CONF_REGION = "region"             # Kept for migration read-out
+CONF_COUNTRY = "country"           # New key stored in v4+ config entries
+CONF_COUNTRY_CUSTOM = "country_custom"
+DEFAULT_COUNTRY = "DE"
+DEFAULT_REGION = "DE"
+DOMAIN = "volkswagencarnet"
+
+COUNTRY_LIST = {
+    "US": "United States",
+    "CA": "Canada",
+    "DE": "Germany",
+    # ... 12 more countries ...
+    "OTHER": "Other (enter country code below)",
+}
+```
+
+From custom_components/volkswagencarnet/__init__.py (migration pattern, lines 139-168):
+```python
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    version = entry.version
+    # v1->v2 block ...
+    # v2->v3 block ...
+    # v3->v4 block goes HERE
+    _LOGGER.info("Migration to config version %s successful", version)
+    return True
+```
+
+From homeassistant.helpers.issue_registry (HA API):
+```python
+ir.async_create_issue(
+    hass, domain, issue_id, is_fixable=True,
+    severity=ir.IssueSeverity.WARNING,
+    translation_key="...", data={...}
+)
+```
+
+From homeassistant.components.repairs (HA API):
+```python
+class RepairsFlow:
+    async def async_step_init(self, user_input=None) -> FlowResult
+    def async_show_form(self, step_id, data_schema, description_placeholders) -> FlowResult
+    def async_create_entry(self, title, data) -> FlowResult
+
+async def async_create_fix_flow(hass, issue_id, data) -> RepairsFlow
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add v3-to-v4 migration and repairs flow</name>
+  <files>custom_components/volkswagencarnet/__init__.py, custom_components/volkswagencarnet/repairs.py, custom_components/volkswagencarnet/strings.json, custom_components/volkswagencarnet/translations/en.json</files>
+  <action>
+**__init__.py -- migration block:**
+
+1. Add import at top of file: `from .const import CONF_COUNTRY, DEFAULT_COUNTRY` (if not already present from Plan 01). Also keep `CONF_REGION` import.
+
+2. In `async_migrate_entry`, after the `if version == 2:` block (line 159-165) and before the `_LOGGER.info(...)` line, add a new v3->v4 migration block:
+
+```python
+# 3 -> 4: Replace CONF_REGION free-text with CONF_COUNTRY dropdown
+if version == 3:
+    version = entry.version = 4
+    data = dict(entry.data)
+    options = dict(entry.options)
+
+    # Move CONF_REGION value to CONF_COUNTRY in data
+    existing_region = data.pop(CONF_REGION, DEFAULT_REGION)
+    data[CONF_COUNTRY] = existing_region
+
+    # Also clean CONF_REGION from options and add CONF_COUNTRY if it was there
+    # (Pitfall 3: options and data are separate dicts, both need updating)
+    if CONF_REGION in options:
+        region_from_options = options.pop(CONF_REGION)
+        options[CONF_COUNTRY] = region_from_options
+
+    hass.config_entries.async_update_entry(entry, data=data, options=options)
+
+    # Create repair so user must confirm their country before reconnecting
+    from homeassistant.helpers import issue_registry as ir
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"confirm_country_{entry.entry_id}",
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="confirm_country",
+        data={"entry_id": entry.entry_id, "country": existing_region},
+    )
+
+    _LOGGER.warning(
+        "Migrated config entry %s from v3 to v4. "
+        "Please confirm your country in Home Assistant Repairs.",
+        entry.entry_id,
+    )
+```
+
+**IMPORTANT:** The `from homeassistant.helpers import issue_registry as ir` import is inside the block intentionally -- this avoids importing it at module level where it may not be needed.
+
+**repairs.py -- new file:**
+
+3. Create `custom_components/volkswagencarnet/repairs.py` with this content:
+
+```python
+"""Repairs flow for Volkswagen Connect integration."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_COUNTRY, COUNTRY_LIST, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfirmCountryRepairFlow(RepairsFlow):
+    """Repair flow: user confirms their country after v3->v4 migration."""
+
+    def __init__(self, data: dict) -> None:
+        """Initialize the repair flow."""
+        super().__init__()
+        self._entry_id: str = data.get("entry_id", "")
+        self._existing_country: str = data.get("country", "DE")
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle init step -- redirect to confirm."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle confirm step -- show country dropdown, update config entry on submit."""
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry:
+                data = dict(entry.data)
+                data[CONF_COUNTRY] = user_input[CONF_COUNTRY]
+                self.hass.config_entries.async_update_entry(entry, data=data)
+                await self.hass.config_entries.async_reload(self._entry_id)
+                _LOGGER.info(
+                    "Country confirmed as '%s' for config entry %s",
+                    user_input[CONF_COUNTRY],
+                    self._entry_id,
+                )
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_COUNTRY, default=self._existing_country
+                    ): vol.In(COUNTRY_LIST),
+                }
+            ),
+            description_placeholders={"country": self._existing_country},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict | None
+) -> RepairsFlow:
+    """Create repair flow for known issues."""
+    if issue_id.startswith("confirm_country_"):
+        return ConfirmCountryRepairFlow(data or {})
+    raise ValueError(f"Unknown repair issue id: {issue_id}")
+```
+
+**strings.json -- add repair issue strings:**
+
+4. Add a top-level `"issues"` key to strings.json (at the same level as `"title"`, `"config"`, `"options"`):
+
+```json
+"issues": {
+    "confirm_country": {
+        "title": "Confirm your country for Volkswagen Connect",
+        "fix_flow": {
+            "step": {
+                "confirm": {
+                    "title": "Confirm your country",
+                    "description": "A configuration update requires confirming the country for your VW vehicle. Your current setting is '{country}'. Please confirm or select the correct country.",
+                    "data": {
+                        "country": "Country"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**translations/en.json -- mirror repair strings:**
+
+5. Add the same `"issues"` block to translations/en.json at the top level.
+
+**Anti-patterns to avoid:**
+- Do NOT silently auto-migrate without a repair notification -- per user decision, user must confirm before integration reconnects.
+- Do NOT forget to clean CONF_REGION from `entry.options` (Pitfall 3 from research -- both data and options dicts need updating).
+- Do NOT remove CONF_REGION constant from const.py -- keep it for migration read-out.
+  </action>
+  <verify>
+    <automated>grep -q "version == 3" custom_components/volkswagencarnet/__init__.py && grep -q "async_create_issue" custom_components/volkswagencarnet/__init__.py && test -f custom_components/volkswagencarnet/repairs.py && grep -q "async_create_fix_flow" custom_components/volkswagencarnet/repairs.py && grep -q "ConfirmCountryRepairFlow" custom_components/volkswagencarnet/repairs.py && python3 -c "import json; d=json.load(open('custom_components/volkswagencarnet/strings.json')); assert 'issues' in d; assert 'confirm_country' in d['issues']; print('strings OK')" && python3 -c "import json; d=json.load(open('custom_components/volkswagencarnet/translations/en.json')); assert 'issues' in d; assert 'confirm_country' in d['issues']; print('en.json OK')"</automated>
+  </verify>
+  <done>async_migrate_entry has v3->v4 block that renames CONF_REGION to CONF_COUNTRY in both data and options, creates a fixable repair issue. repairs.py exists with ConfirmCountryRepairFlow that shows country dropdown pre-populated with existing value, updates config entry on confirmation, and reloads the integration. strings.json and en.json have repair issue strings.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update README with NA setup instructions</name>
+  <files>README.md</files>
+  <action>
+Read the existing README.md first. Add a new section after the existing setup/installation instructions (or near the top if no setup section exists). The section should cover:
+
+1. **Section title**: `## Setup for North American Users` (or integrate into existing setup section if one exists)
+
+2. **Content** (target audience: HA admin users who can install custom integrations):
+
+- Explain that the integration now supports both North American and European VW Connect accounts
+- During setup, users select their country from a dropdown (US, CA, DE, etc.)
+- The integration automatically routes to the correct VW backend based on the selected country
+- US and Canadian users: select your country and use your VW Car-Net credentials (same as the VW Car-Net mobile app)
+- EU users: select your country and use your We Connect / Volkswagen Connect credentials
+- If your country is not in the dropdown, select "Other" and enter your 2-letter ISO country code
+- An active VW Connect / Car-Net subscription is required for the vehicle
+- S-PIN is required for lock/unlock operations (optional)
+
+3. **Upgrading from a previous version** (brief note):
+- If upgrading from a version that used a free-text region code, you will see a repair notification in Home Assistant
+- Go to Settings > System > Repairs, click "Fix", and confirm your country
+- The integration will reload automatically after confirmation
+
+Keep the README update focused and concise. Do NOT rewrite the entire README -- add/modify only the relevant sections.
+  </action>
+  <verify>
+    <automated>grep -q "North America" README.md && grep -q "country" README.md && grep -q "Repairs" README.md</automated>
+  </verify>
+  <done>README.md contains NA setup section explaining country picker, instructions for US/CA users, and upgrade note about the Repairs confirmation flow</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `grep "version == 3" custom_components/volkswagencarnet/__init__.py` confirms migration block exists.
+2. `grep "async_create_issue" custom_components/volkswagencarnet/__init__.py` confirms repair is created.
+3. `python3 -c "import ast; ast.parse(open('custom_components/volkswagencarnet/repairs.py').read()); print('syntax OK')"` confirms repairs.py is valid Python.
+4. `python3 -c "import json; json.load(open('custom_components/volkswagencarnet/strings.json')); print('valid JSON')"` confirms strings.json is valid.
+5. README.md mentions North America, country selector, and Repairs flow.
+</verification>
+
+<success_criteria>
+- async_migrate_entry handles v3->v4: renames CONF_REGION to CONF_COUNTRY in data AND options
+- Migration creates a fixable repair issue via issue_registry.async_create_issue
+- repairs.py defines ConfirmCountryRepairFlow with async_step_confirm showing country dropdown
+- Repair flow pre-populates with existing country value and reloads integration after confirmation
+- async_create_fix_flow dispatches to ConfirmCountryRepairFlow for confirm_country_ issues
+- strings.json and en.json have issues.confirm_country with title, fix_flow, step, and data labels
+- README documents NA setup with country picker, US/CA instructions, and upgrade migration note
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-na-library-integration/02-02-SUMMARY.md`
+</output>

--- a/.planning/phases/02-na-library-integration/02-02-SUMMARY.md
+++ b/.planning/phases/02-na-library-integration/02-02-SUMMARY.md
@@ -1,0 +1,115 @@
+---
+phase: 02-na-library-integration
+plan: 02
+subsystem: config
+tags: [home-assistant, repairs, config-migration, volkswagencarnet, country-selector]
+
+# Dependency graph
+requires:
+  - phase: 02-na-library-integration
+    plan: 01
+    provides: CONF_COUNTRY, COUNTRY_LIST, DEFAULT_COUNTRY in const.py; config flow v4 with country dropdown
+provides:
+  - v3->v4 migration block in async_migrate_entry (renames CONF_REGION to CONF_COUNTRY in data and options)
+  - HA Repairs fixable issue created after migration (confirm_country_{entry_id})
+  - repairs.py with ConfirmCountryRepairFlow and async_create_fix_flow
+  - Repair UI strings in strings.json and translations/en.json
+  - README North America setup section and upgrade instructions
+affects:
+  - Future config entry handling (version 4 is now the current version)
+  - Existing EU users upgrading (Repairs notification guides them to confirm country)
+
+# Tech tracking
+tech-stack:
+  added: [homeassistant.components.repairs.RepairsFlow, homeassistant.helpers.issue_registry]
+  patterns:
+    - HA Repairs framework for post-migration user confirmation
+    - Inline import of issue_registry inside migration block to avoid module-level dependency
+    - async_create_fix_flow dispatcher pattern for routing repair issues to flows
+
+key-files:
+  created:
+    - custom_components/volkswagencarnet/repairs.py
+  modified:
+    - custom_components/volkswagencarnet/__init__.py
+    - custom_components/volkswagencarnet/strings.json
+    - custom_components/volkswagencarnet/translations/en.json
+    - README.md
+
+key-decisions:
+  - "Inline import of issue_registry inside v3->v4 block to avoid importing at module level where it may not be needed"
+  - "Repair issue ID uses entry_id suffix (confirm_country_{entry_id}) to support multiple vehicles"
+  - "async_create_fix_flow raises ValueError for unknown issue IDs to surface unexpected repair registrations"
+
+patterns-established:
+  - "HA Repairs pattern: async_migrate_entry creates issue -> repairs.py handles async_create_fix_flow -> ConfirmCountryRepairFlow shows form"
+  - "Migration pattern: pop old key, set new key in both data and options dicts before calling async_update_entry"
+
+requirements-completed: [NAL-05, NAL-07]
+
+# Metrics
+duration: 2min
+completed: 2026-03-07
+---
+
+# Phase 02 Plan 02: NA Library Integration Migration Summary
+
+**v3->v4 config entry migration with HA Repairs country confirmation flow and North America README documentation**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-07T15:54:44Z
+- **Completed:** 2026-03-07T15:56:31Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+
+- Added v3->v4 migration block to `async_migrate_entry` that renames `CONF_REGION` to `CONF_COUNTRY` in both `entry.data` and `entry.options`, then creates a fixable HA Repairs issue
+- Created `repairs.py` with `ConfirmCountryRepairFlow` that shows a pre-populated country dropdown and reloads the integration after user confirmation
+- Added `issues.confirm_country` strings to both `strings.json` and `translations/en.json` for the Repairs UI
+- Updated README with a dedicated North America Setup section explaining the country picker, VW Car-Net credentials for US/CA users, and upgrade instructions for the Repairs notification flow
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add v3-to-v4 migration and repairs flow** - `459a339` (feat)
+2. **Task 2: Update README with NA setup instructions** - `91ef1dc` (docs)
+
+## Files Created/Modified
+
+- `custom_components/volkswagencarnet/__init__.py` - Added v3->v4 migration block with async_create_issue call
+- `custom_components/volkswagencarnet/repairs.py` - New file: ConfirmCountryRepairFlow and async_create_fix_flow
+- `custom_components/volkswagencarnet/strings.json` - Added issues.confirm_country repair strings
+- `custom_components/volkswagencarnet/translations/en.json` - Added issues.confirm_country repair strings (EN)
+- `README.md` - Added North America Setup section and updated Configuration section
+
+## Decisions Made
+
+- Inline import of `issue_registry as ir` inside the `if version == 3:` block, consistent with HA patterns and avoids module-level import of a module only needed during migration
+- Repair issue ID uses `entry_id` suffix (`confirm_country_{entry.entry_id}`) so multi-vehicle setups each get their own repair notification
+- `async_create_fix_flow` raises `ValueError` for unknown issue IDs to surface unexpected dispatch
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Migration and documentation complete; Phase 02 (NA Library Integration) is now fully implemented
+- Existing EU users who upgrade will see the Repairs notification and can confirm their country without manual intervention
+- NA users have clear README instructions for initial setup
+
+---
+*Phase: 02-na-library-integration*
+*Completed: 2026-03-07*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
+      - id: detect-private-key
       - id: check-added-large-files
       - id: check-json
       - id: check-toml
@@ -41,3 +42,9 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [ types-freezegun==1.1.6 ]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,242 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.planning/|config/"
+      ]
+    }
+  ],
+  "results": {
+    "custom_components/volkswagencarnet/translations/da.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/da.json",
+        "hashed_secret": "2ea63c64a46bcb4da9bb80b5c4d3c2c5b332c11f",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/de.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/de.json",
+        "hashed_secret": "0719708d1cc814839bd818fdc27d446652f03383",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/en.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/en.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/fi.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/fi.json",
+        "hashed_secret": "1edab3c25a852fdf601720cb0d533c3ca4374779",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/nb.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/nb.json",
+        "hashed_secret": "0bcfb4cb7d7779094d3ae6d319be4f9ec248cf96",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/nl.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/nl.json",
+        "hashed_secret": "8278b30ef12fdf2ca2aaa363ea2f2504f0543357",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/nn.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/nn.json",
+        "hashed_secret": "0bcfb4cb7d7779094d3ae6d319be4f9ec248cf96",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/pl.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/pl.json",
+        "hashed_secret": "f6240c78d748397cfa3a1bf65767e2e127ba877c",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/pt-BR.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/pt-BR.json",
+        "hashed_secret": "deba0172511d5701d964202f4e5de698d5e07c67",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/ru.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/ru.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "custom_components/volkswagencarnet/translations/sl.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/volkswagencarnet/translations/sl.json",
+        "hashed_secret": "c361da0c65f9710ff0430bdec28a0c7e1c716639",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "tests/config_flow_test.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/config_flow_test.py",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ]
+  },
+  "generated_at": "2026-03-03T22:39:07Z"
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 
-# Volkswagen Connect - An Home Assistant custom component to interact with the VW Connect service. (EU ONLY)
+# Volkswagen Connect - An Home Assistant custom component to interact with the VW Connect service. (EU & US ONLY)
 
 ## Support the Project
 
@@ -26,7 +26,7 @@ This component supports **Volkswagen Connect vehicles** such as the Passat, Golf
 
 Most of the features available in the official "Volkswagen Connect" app are accessible through this integration.
 
-> **Note:** So far, this component has only been reported to work successfully with cars sold in the **EU**. Contributions to support vehicles outside the EU, such as in the US, are welcome. Currently, we do not have access to non-EU VW Connect accounts to verify functionality.
+> **Note:** So far, this component has only been reported to work successfully with cars sold in the **EU** & **US**. Contributions to support vehicles outside the EU are welcome.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This component supports **Volkswagen Connect vehicles** such as the Passat, Golf
 
 Most of the features available in the official "Volkswagen Connect" app are accessible through this integration.
 
-> **Note:** So far, this component has only been reported to work successfully with cars sold in the **EU**. Contributions to support vehicles outside the EU, such as in the US, are welcome. Currently, we do not have access to non-EU VW Connect accounts to verify functionality.
+This integration supports both **European** (We Connect / Volkswagen Connect) and **North American** (VW Car-Net) accounts. See the [North America Setup](#setup-for-north-american-users) section below for details.
 
 ## Installation
 
@@ -55,6 +55,33 @@ Note that only the packaged releases (zip file) have the dependencies configured
 
 </details>
 
+## Setup for North American Users
+
+This integration supports both North American (US/CA) and European VW Connect accounts.
+
+During setup, you select your country from a dropdown (United States, Canada, Germany, etc.). The integration automatically routes to the correct VW backend based on the selected country — no additional configuration is needed.
+
+**US and Canadian users:** Select your country (United States or Canada) and use your **VW Car-Net** credentials — the same email and password you use in the VW Car-Net mobile app.
+
+**European users:** Select your country and use your **We Connect / Volkswagen Connect** credentials.
+
+**Country not in the list?** Select "Other (enter country code below)" and enter your 2-letter ISO 3166-1 alpha-2 country code (e.g., `NL`, `SE`, `NO`).
+
+**Requirements:**
+- An active VW Connect / Car-Net subscription for the vehicle is required
+- S-PIN is required for lock/unlock operations (optional for other features)
+
+### Upgrading from a Previous Version
+
+If you are upgrading from a version that used a free-text region code, you will see a **repair notification** in Home Assistant after the upgrade.
+
+1. Go to **Settings > System > Repairs**
+2. Click **Fix** on the "Confirm your country for Volkswagen Connect" notification
+3. Confirm or select the correct country from the dropdown
+4. The integration reloads automatically after confirmation
+
+---
+
 ## Configuration
 * Restart Home Assistant
 * Add and configure the component via the UI: Configuration > Integrations > search for "Volkswagen Connect" and follow the wizard to configure (use your Volkswagen Connect credentials)
@@ -62,8 +89,8 @@ Note that only the packaged releases (zip file) have the dependencies configured
 
 ### Configuration flow settings
 * Name your car - Enter a custom name, defaults to VIN (Optional)
-* Username/Password - Volkswagen Connect (Required)
-* Region - The country where the car was sold (Required)
+* Username/Password - Volkswagen Connect / VW Car-Net (Required)
+* Country - The country where your car was sold (Required). US and Canadian users select their country to connect via the North American VW Car-Net backend.
 * Mutable - If enabled you can interact with the car, if disabled only data from the car will be presented (Optional)
 * S-PIN - Required for some specific options such as lock/unlock (Optional)
 * Distance unit conversion - Select if you wish to use "Scandinavian mile (mil)" or Imperial Miles (mi) instead of km (Optional, default is km)

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,7 @@
+default_config:
+
+logger:
+  default: info
+  logs:
+    custom_components.volkswagencarnet: debug
+    volkswagencarnet: debug

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.update_coordinator import (
 
 # pylint: disable=no-name-in-module,hass-relative-import
 from volkswagencarnet.vw_connection import Connection
+from volkswagencarnet.vw_exceptions import AuthenticationError, VWError
 from volkswagencarnet.vw_dashboard import (
     BinarySensor,
     DoorLock,
@@ -589,6 +590,7 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
             username=self.entry.data[CONF_USERNAME],
             password=self.entry.data[CONF_PASSWORD],
             country=self.entry.data.get(CONF_COUNTRY, self.entry.data.get(CONF_REGION, DEFAULT_COUNTRY)),
+            spin=self.entry.data.get(CONF_SPIN),
         )
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
@@ -645,8 +647,11 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
             if self.connection.logged_in:
                 await self.connection.logout()
                 _LOGGER.debug("Successfully logged out")
+        except VWError as err:
+            _LOGGER.error("Could not log out from Volkswagen Connect (library error): %s", err)
+            return False
         except Exception as err:  # pylint: disable=broad-exception-caught
-            _LOGGER.error("Could not log out from Volkswagen Connect: %s", err)
+            _LOGGER.error("Could not log out from Volkswagen Connect (unexpected error): %s", err)
             return False
 
         return True
@@ -659,8 +664,14 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
 
         try:
             await self.connection.doLogin(3)
+        except AuthenticationError as err:
+            _LOGGER.error("Authentication failed: %s", err)
+            return False
+        except VWError as err:
+            _LOGGER.error("Login failed (library error): %s", err)
+            return False
         except Exception as err:  # pylint: disable=broad-exception-caught
-            _LOGGER.error("Login failed: %s", err)
+            _LOGGER.error("Login failed (unexpected error): %s", err)
             return False
 
         if not self.connection.logged_in:
@@ -694,6 +705,9 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
 
             _LOGGER.debug("Updated data for VIN %s", self.vin)
             return self.vehicle
+        except VWError as err:
+            _LOGGER.error("VW API error during update for VIN %s: %s", self.vin, err)
+            return None
         except Exception as err:  # pylint: disable=broad-exception-caught
-            _LOGGER.error("Error during update for VIN %s: %s", self.vin, err)
+            _LOGGER.error("Unexpected error during update for VIN %s: %s", self.vin, err)
             return None

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -166,6 +166,43 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 
+    # 3 -> 4: Replace CONF_REGION free-text with CONF_COUNTRY dropdown
+    if version == 3:
+        version = entry.version = 4
+        data = dict(entry.data)
+        options = dict(entry.options)
+
+        # Move CONF_REGION value to CONF_COUNTRY in data
+        existing_region = data.pop(CONF_REGION, DEFAULT_COUNTRY)
+        data[CONF_COUNTRY] = existing_region
+
+        # Also clean CONF_REGION from options and add CONF_COUNTRY if it was there
+        # (both data and options are separate dicts, both need updating)
+        if CONF_REGION in options:
+            region_from_options = options.pop(CONF_REGION)
+            options[CONF_COUNTRY] = region_from_options
+
+        hass.config_entries.async_update_entry(entry, data=data, options=options)
+
+        # Create repair so user must confirm their country before reconnecting
+        from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"confirm_country_{entry.entry_id}",
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="confirm_country",
+            data={"entry_id": entry.entry_id, "country": existing_region},
+        )
+
+        _LOGGER.warning(
+            "Migrated config entry %s from v3 to v4. "
+            "Please confirm your country in Home Assistant Repairs.",
+            entry.entry_id,
+        )
+
     _LOGGER.info("Migration to config version %s successful", version)
     return True
 

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -46,6 +46,7 @@ from .const import (
     COMPONENTS,
     CONF_AVAILABLE_RESOURCES,
     CONF_CONVERT,
+    CONF_COUNTRY,
     CONF_IMPERIAL_UNITS,
     CONF_MUTABLE,
     CONF_NO_CONVERSION,
@@ -54,6 +55,7 @@ from .const import (
     CONF_SPIN,
     CONF_VEHICLE,
     DATA,
+    DEFAULT_COUNTRY,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     SIGNAL_STATE_UPDATED,
@@ -549,7 +551,7 @@ class VolkswagenCoordinator(DataUpdateCoordinator):
             session=async_get_clientsession(hass),
             username=self.entry.data[CONF_USERNAME],
             password=self.entry.data[CONF_PASSWORD],
-            country=self.entry.options.get(CONF_REGION, self.entry.data[CONF_REGION]),
+            country=self.entry.data.get(CONF_COUNTRY, self.entry.data.get(CONF_REGION, DEFAULT_COUNTRY)),
         )
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)

--- a/custom_components/volkswagencarnet/__init__.py
+++ b/custom_components/volkswagencarnet/__init__.py
@@ -147,7 +147,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # 1 -> 2: Move resources from data -> options
     if version == 1:
         default_convert_conf = get_convert_conf(entry)
-        version = entry.version = 2
+        version = 2
         options = dict(entry.options)
         data = dict(entry.data)
 
@@ -155,20 +155,20 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         options[CONF_CONVERT] = options.get(CONF_CONVERT, default_convert_conf)
         data.pop(CONF_RESOURCES, None)
 
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
+        hass.config_entries.async_update_entry(entry, data=data, options=options, version=2)
 
     # 2 -> 3: Fix empty "convert" option
     if version == 2:
-        version = entry.version = 3
+        version = 3
         options = dict(entry.options)
         options.pop(CONF_CONVERT, None)
         data = dict(entry.data)
 
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
+        hass.config_entries.async_update_entry(entry, data=data, options=options, version=3)
 
     # 3 -> 4: Replace CONF_REGION free-text with CONF_COUNTRY dropdown
     if version == 3:
-        version = entry.version = 4
+        version = 4
         data = dict(entry.data)
         options = dict(entry.options)
 
@@ -182,7 +182,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             region_from_options = options.pop(CONF_REGION)
             options[CONF_COUNTRY] = region_from_options
 
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
+        hass.config_entries.async_update_entry(entry, data=data, options=options, version=4)
 
         # Create repair so user must confirm their country before reconnecting
         from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415

--- a/custom_components/volkswagencarnet/config_flow.py
+++ b/custom_components/volkswagencarnet/config_flow.py
@@ -27,12 +27,16 @@ from volkswagencarnet.vw_vehicle import Vehicle
 from .const import (
     CONF_AVAILABLE_RESOURCES,
     CONF_CONVERT,
+    CONF_COUNTRY,
+    CONF_COUNTRY_CUSTOM,
     CONF_MUTABLE,
     CONF_NO_CONVERSION,
     CONF_REGION,
     CONF_SPIN,
     CONF_VEHICLE,
     CONVERT_DICT,
+    COUNTRY_LIST,
+    DEFAULT_COUNTRY,
     DEFAULT_REGION,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
@@ -47,7 +51,8 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME, default=""): str,
         vol.Required(CONF_PASSWORD, default=""): str,
         vol.Optional(CONF_SPIN, default=""): str,
-        vol.Optional(CONF_REGION, default=DEFAULT_REGION): str,
+        vol.Required(CONF_COUNTRY): vol.In(COUNTRY_LIST),
+        vol.Optional(CONF_COUNTRY_CUSTOM, default=""): str,
         vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
         vol.Optional(CONF_CONVERT, default=CONF_NO_CONVERSION): vol.In(CONVERT_DICT),
         vol.Optional(
@@ -60,7 +65,7 @@ DATA_SCHEMA = vol.Schema(
 class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config Flow for Volkswagen Connect."""
 
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self) -> None:
         """Initialize config flow."""
@@ -77,12 +82,23 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._init_info = user_input
             self.task_login = None
 
+            # Collapse "Other" free-text into CONF_COUNTRY
+            if self._init_info.get(CONF_COUNTRY) == "OTHER":
+                custom_code = self._init_info.pop(CONF_COUNTRY_CUSTOM, "").strip().upper()
+                if len(custom_code) != 2:
+                    self._errors[CONF_COUNTRY_CUSTOM] = "invalid_country_code"
+                    return self.async_show_form(
+                        step_id="user", data_schema=DATA_SCHEMA, errors=self._errors
+                    )
+                self._init_info[CONF_COUNTRY] = custom_code
+            self._init_info.pop(CONF_COUNTRY_CUSTOM, None)  # Don't store in config entry
+
             _LOGGER.debug("Creating connection to Volkswagen Connect")
             self._connection = Connection(
                 session=async_get_clientsession(self.hass),
                 username=self._init_info[CONF_USERNAME],
                 password=self._init_info[CONF_PASSWORD],
-                country=self._init_info[CONF_REGION],
+                country=self._init_info[CONF_COUNTRY],
             )
 
             return await self.async_step_login()
@@ -221,9 +237,7 @@ class VolkswagenCarnetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 session=async_get_clientsession(self.hass),
                 username=user_input[CONF_USERNAME],
                 password=user_input[CONF_PASSWORD],
-                country=self._entry.options.get(
-                    CONF_REGION, self._entry.data[CONF_REGION]
-                ),
+                country=self._entry.data.get(CONF_COUNTRY, self._entry.data.get(CONF_REGION, DEFAULT_COUNTRY)),
             )
 
             try:
@@ -302,11 +316,11 @@ class VolkswagenCarnetOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self._config_entry.data.get(CONF_SPIN, ""),
                     ): str,
                     vol.Optional(
-                        CONF_REGION,
-                        default=self._config_entry.options.get(
-                            CONF_REGION, self._config_entry.data[CONF_REGION]
+                        CONF_COUNTRY,
+                        default=self._config_entry.data.get(
+                            CONF_COUNTRY, self._config_entry.data.get(CONF_REGION, DEFAULT_COUNTRY)
                         ),
-                    ): str,
+                    ): vol.In(COUNTRY_LIST),
                     vol.Optional(
                         CONF_MUTABLE,
                         default=self._config_entry.data.get(CONF_MUTABLE, True),

--- a/custom_components/volkswagencarnet/const.py
+++ b/custom_components/volkswagencarnet/const.py
@@ -7,6 +7,29 @@ DATA_KEY = DOMAIN
 
 DEFAULT_REGION = "DE"
 
+CONF_COUNTRY = "country"
+CONF_COUNTRY_CUSTOM = "country_custom"
+DEFAULT_COUNTRY = "DE"  # Used only as migration fallback
+
+COUNTRY_LIST = {
+    "US": "United States",
+    "CA": "Canada",
+    "DE": "Germany",
+    "GB": "United Kingdom",
+    "NL": "Netherlands",
+    "SE": "Sweden",
+    "NO": "Norway",
+    "FR": "France",
+    "IT": "Italy",
+    "ES": "Spain",
+    "AT": "Austria",
+    "CH": "Switzerland",
+    "DK": "Denmark",
+    "FI": "Finland",
+    "BE": "Belgium",
+    "OTHER": "Other (enter country code below)",
+}
+
 CONF_REGION = "region"
 CONF_MUTABLE = "mutable"
 CONF_SPIN = "spin"

--- a/custom_components/volkswagencarnet/manifest.json
+++ b/custom_components/volkswagencarnet/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/robinostlund/homeassistant-volkswagencarnet/issues",
   "loggers": ["volkswagencarnet"],
-  "requirements": [],
+  "requirements": ["volkswagencarnet @ git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main"],
   "version": "v0.0.0"
 }

--- a/custom_components/volkswagencarnet/repairs.py
+++ b/custom_components/volkswagencarnet/repairs.py
@@ -1,0 +1,70 @@
+"""Repairs flow for Volkswagen Connect integration."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_COUNTRY, COUNTRY_LIST, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ConfirmCountryRepairFlow(RepairsFlow):
+    """Repair flow: user confirms their country after v3->v4 migration."""
+
+    def __init__(self, data: dict) -> None:
+        """Initialize the repair flow."""
+        super().__init__()
+        self._entry_id: str = data.get("entry_id", "")
+        self._existing_country: str = data.get("country", "DE")
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle init step -- redirect to confirm."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle confirm step -- show country dropdown, update config entry on submit."""
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry:
+                data = dict(entry.data)
+                data[CONF_COUNTRY] = user_input[CONF_COUNTRY]
+                self.hass.config_entries.async_update_entry(entry, data=data)
+                await self.hass.config_entries.async_reload(self._entry_id)
+                _LOGGER.info(
+                    "Country confirmed as '%s' for config entry %s",
+                    user_input[CONF_COUNTRY],
+                    self._entry_id,
+                )
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_COUNTRY, default=self._existing_country
+                    ): vol.In(COUNTRY_LIST),
+                }
+            ),
+            description_placeholders={"country": self._existing_country},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict | None
+) -> RepairsFlow:
+    """Create repair flow for known issues."""
+    if issue_id.startswith("confirm_country_"):
+        return ConfirmCountryRepairFlow(data or {})
+    raise ValueError(f"Unknown repair issue id: {issue_id}")

--- a/custom_components/volkswagencarnet/strings.json
+++ b/custom_components/volkswagencarnet/strings.json
@@ -9,10 +9,10 @@
           "username": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]",
           "mutable": "Uncheck to make the car 'read only'. Keep checked to interact with the car",
-          "region": "Region (The country where the car was sold)",
+          "country": "Country where your car was sold",
+          "country_custom": "Custom country code (ISO 3166-1 alpha-2, only if 'Other' selected above)",
           "spin": "S-PIN",
           "name": "Name your car (defaults to VIN number)",
-          "debug": "Enable full debug logs from API (requires debug logging enabled in config)",
           "convert": "Select if you wan to make any distance unit conversions",
           "scan_interval": "Sensors update interval (minutes)"
         }
@@ -46,6 +46,7 @@
     "error": {
       "cannot_connect": "Could not login to Volkswagen Connect, please check your credentials and verify that the service is working. This can be caused by an update to terms and conditions, try logging in using the app or https://www.myvolkswagen.net/.",
       "cannot_update": "Could not query update from Volkswagen Connect",
+      "invalid_country_code": "Please enter a valid 2-letter country code (e.g. US, DE, NL)",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "progress": {
@@ -60,7 +61,7 @@
         "description": "Configure Volkswagen Connect settings",
         "data": {
           "spin": "S-PIN (required for lock/unlock and heating)",
-          "region": "Region (The country where the car was sold)",
+          "country": "Country where your car was sold",
           "mutable": "Enable car control (uncheck for read-only mode)",
           "convert": "Select if you want to make any distance unit conversions",
           "scan_interval": "Sensors update interval (minutes)"

--- a/custom_components/volkswagencarnet/strings.json
+++ b/custom_components/volkswagencarnet/strings.json
@@ -75,5 +75,21 @@
         }
       }
     }
+  },
+  "issues": {
+    "confirm_country": {
+      "title": "Confirm your country for Volkswagen Connect",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Confirm your country",
+            "description": "A configuration update requires confirming the country for your VW vehicle. Your current setting is '{country}'. Please confirm or select the correct country.",
+            "data": {
+              "country": "Country"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/volkswagencarnet/translations/en.json
+++ b/custom_components/volkswagencarnet/translations/en.json
@@ -9,10 +9,10 @@
           "username": "Email",
           "password": "Password",
           "mutable": "Uncheck to make the car 'read only'. Keep checked to interact with the car",
-          "region": "Country code where the car was sold (ISO 3166-1 alpha-2)",
+          "country": "Country where your car was sold",
+          "country_custom": "Custom country code (ISO 3166-1 alpha-2, only if 'Other' selected above)",
           "spin": "S-PIN",
           "name": "Name your car (defaults to VIN number)",
-          "debug": "Enable full debug logs from API (requires debug logging enabled in config)",
           "convert": "Select if you want to make any distance unit conversions",
           "scan_interval": "Sensors update interval (minutes)"
         }
@@ -46,6 +46,7 @@
     "error": {
       "cannot_connect": "Could not login to Volkswagen Connect, please check your credentials and verify that the service is working. This can be caused by an update to terms and conditions, try logging in using the app or https://www.myvolkswagen.net/.",
       "cannot_update": "Could not query update from Volkswagen Connect",
+      "invalid_country_code": "Please enter a valid 2-letter country code (e.g. US, DE, NL)",
       "unknown": "An unknown error occurred"
     },
     "progress": {
@@ -60,7 +61,7 @@
         "description": "Configure Volkswagen Connect settings",
         "data": {
           "spin": "S-PIN (required for lock/unlock and heating)",
-          "region": "Region (The country where the car was sold)",
+          "country": "Country where your car was sold",
           "mutable": "Enable car control (uncheck for read-only mode)",
           "convert": "Select if you want to make any distance unit conversions",
           "scan_interval": "Sensors update interval (minutes)"

--- a/custom_components/volkswagencarnet/translations/en.json
+++ b/custom_components/volkswagencarnet/translations/en.json
@@ -75,5 +75,21 @@
         }
       }
     }
+  },
+  "issues": {
+    "confirm_country": {
+      "title": "Confirm your country for Volkswagen Connect",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Confirm your country",
+            "description": "A configuration update requires confirming the country for your VW vehicle. Your current setting is '{country}'. Please confirm or select the correct country.",
+            "data": {
+              "country": "Country"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -40,7 +40,7 @@ services:
       - ./entrypoint.sh:/config/dev-entrypoint.sh:ro
       - ../requirements.txt:/requirements.txt:ro
     ports:
-      # NOTE: Stop default service first — port 8123 cannot be shared
+      # NOTE: Stop default service first — port 9123 cannot be shared
       - "9123:8123"
     dns:
       - 8.8.8.8

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -1,0 +1,46 @@
+# VW CarNet Home Assistant development environment
+#
+# Usage:
+#   Default (persistent config):
+#     cd dev && docker compose up
+#     Open http://localhost:8123 in your browser
+#
+#   Fresh (clean slate, no prior HA config):
+#     cd dev && docker compose --profile fresh up
+#     NOTE: Stop the default service first — both use port 8123
+
+services:
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: ha-dev
+    entrypoint: ["/config/dev-entrypoint.sh"]
+    volumes:
+      - ../config:/config
+      - ../custom_components:/config/custom_components
+      - ./entrypoint.sh:/config/dev-entrypoint.sh:ro
+      - ../requirements.txt:/requirements.txt:ro
+    ports:
+      - "8123:8123"
+    environment:
+      TZ: America/New_York
+    restart: unless-stopped
+
+  homeassistant-fresh:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: ha-dev-fresh
+    entrypoint: ["/config/dev-entrypoint.sh"]
+    profiles:
+      - fresh
+    volumes:
+      - ha-fresh-config:/config
+      - ../custom_components:/config/custom_components
+      - ./entrypoint.sh:/config/dev-entrypoint.sh:ro
+      - ../requirements.txt:/requirements.txt:ro
+    ports:
+      # NOTE: Stop default service first — port 8123 cannot be shared
+      - "8123:8123"
+    environment:
+      TZ: America/New_York
+
+volumes:
+  ha-fresh-config:

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -3,11 +3,11 @@
 # Usage:
 #   Default (persistent config):
 #     cd dev && docker compose up
-#     Open http://localhost:8123 in your browser
+#     Open http://localhost:9123 in your browser
 #
 #   Fresh (clean slate, no prior HA config):
 #     cd dev && docker compose --profile fresh up
-#     NOTE: Stop the default service first — both use port 8123
+#     NOTE: Stop the default service first — both use port 9123
 
 services:
   homeassistant:
@@ -20,7 +20,10 @@ services:
       - ./entrypoint.sh:/config/dev-entrypoint.sh:ro
       - ../requirements.txt:/requirements.txt:ro
     ports:
-      - "8123:8123"
+      - "9123:8123"
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
     environment:
       TZ: America/New_York
     restart: unless-stopped
@@ -38,7 +41,10 @@ services:
       - ../requirements.txt:/requirements.txt:ro
     ports:
       # NOTE: Stop default service first — port 8123 cannot be shared
-      - "8123:8123"
+      - "9123:8123"
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
     environment:
       TZ: America/New_York
 

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -5,7 +5,7 @@ echo "[dev-entrypoint] Starting VW CarNet development environment"
 
 if [ -f /requirements.txt ]; then
     echo "[dev-entrypoint] Installing requirements from /requirements.txt"
-    pip install --quiet --no-cache-dir -r /requirements.txt
+    pip install --quiet --no-cache-dir --force-reinstall -r /requirements.txt
     echo "[dev-entrypoint] Requirements installed"
 else
     echo "[dev-entrypoint] No /requirements.txt found, skipping pip install"

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+echo "[dev-entrypoint] Starting VW CarNet development environment"
+
+if [ -f /requirements.txt ]; then
+    echo "[dev-entrypoint] Installing requirements from /requirements.txt"
+    pip install --quiet --no-cache-dir -r /requirements.txt
+    echo "[dev-entrypoint] Requirements installed"
+else
+    echo "[dev-entrypoint] No /requirements.txt found, skipping pip install"
+fi
+
+echo "[dev-entrypoint] Launching Home Assistant"
+exec python -m homeassistant --config /config "$@"

--- a/dev/watch.sh
+++ b/dev/watch.sh
@@ -31,9 +31,8 @@ do_restart() {
 if command -v inotifywait &>/dev/null; then
     echo "[watch] Using inotifywait (inotify-tools)"
     while true; do
-        # --polling for reliability on all filesystem types (incl. network/bind mounts)
         # close_write: file saved; moved_to: atomic save (editors like vim)
-        inotifywait --polling -r -e close_write,moved_to \
+        inotifywait -r -e close_write,moved_to \
             --include '\.py$' \
             "${WATCH_DIR}" &>/dev/null
         do_restart

--- a/dev/watch.sh
+++ b/dev/watch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# watch.sh -- Host-side file watcher for VW CarNet HA integration development
+#
+# Monitors custom_components/ for .py file changes and auto-restarts the HA container.
+# Run this on the HOST machine (not inside the container).
+#
+# Usage:
+#   cd dev && ./watch.sh
+#   HA_CONTAINER=my-container ./watch.sh   # override container name
+
+set -e
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+WATCH_DIR="$(realpath "${SCRIPT_DIR}/../custom_components")"
+HA_CONTAINER="${HA_CONTAINER:-ha-dev}"
+DEBOUNCE_SECS=2
+
+echo "[watch] Watching: ${WATCH_DIR}"
+echo "[watch] Container: ${HA_CONTAINER}"
+echo "[watch] Debounce: ${DEBOUNCE_SECS}s after last change"
+echo "[watch] Press Ctrl+C to stop"
+
+do_restart() {
+    echo "[watch] Change detected — waiting ${DEBOUNCE_SECS}s for writes to settle..."
+    sleep "${DEBOUNCE_SECS}"
+    echo "[watch] Restarting container: ${HA_CONTAINER}"
+    docker restart "${HA_CONTAINER}"
+    echo "[watch] Container restarted. Resuming watch..."
+}
+
+if command -v inotifywait &>/dev/null; then
+    echo "[watch] Using inotifywait (inotify-tools)"
+    while true; do
+        # --polling for reliability on all filesystem types (incl. network/bind mounts)
+        # close_write: file saved; moved_to: atomic save (editors like vim)
+        inotifywait --polling -r -e close_write,moved_to \
+            --include '\.py$' \
+            "${WATCH_DIR}" &>/dev/null
+        do_restart
+    done
+else
+    echo "[watch] inotifywait not found — falling back to polling (install inotify-tools for better performance)"
+    prev_hash=""
+    while true; do
+        # Compute combined md5 of all .py files in watch dir
+        current_hash=$(find "${WATCH_DIR}" -name "*.py" -type f -exec md5sum {} + 2>/dev/null | sort | md5sum | awk '{print $1}')
+        if [ -n "${prev_hash}" ] && [ "${current_hash}" != "${prev_hash}" ]; then
+            do_restart
+        fi
+        prev_hash="${current_hash}"
+        sleep 2
+    done
+fi

--- a/dev/watch.sh
+++ b/dev/watch.sh
@@ -34,7 +34,7 @@ if command -v inotifywait &>/dev/null; then
         # close_write: file saved; moved_to: atomic save (editors like vim)
         inotifywait -r -e close_write,moved_to \
             --include '\.py$' \
-            "${WATCH_DIR}" &>/dev/null
+            "${WATCH_DIR}" >/dev/null
         do_restart
     done
 else

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-volkswagencarnet==5.4.5
+volkswagencarnet @ git+https://github.com/Pascal-ZeGerman/volkswagencarnet@main

--- a/tests/test_na_integration.py
+++ b/tests/test_na_integration.py
@@ -592,22 +592,12 @@ async def _run_migration(hass: HomeAssistant, entry):
         return await async_migrate_entry(hass, entry)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "ESCALATE IMPL-BUG-01: async_migrate_entry uses the forbidden direct "
-        "`entry.version = N` assignment pattern. HA >= 2026.x enforces that version "
-        "can only be changed via async_update_entry(entry, version=N). "
-        "Fix: use hass.config_entries.async_update_entry(entry, version=4, data=data, options=options) "
-        "and remove the `entry.version = 4` direct assignment in __init__.py."
-    ),
-    raises=AttributeError,
-    strict=True,
-)
-async def test_nal05_migration_version_assignment_raises(hass: HomeAssistant):
-    """ESCALATE IMPL-BUG-01: direct entry.version assignment raises AttributeError in HA >= 2026.x.
+async def test_nal05_migration_no_version_assignment_error(hass: HomeAssistant):
+    """Verify IMPL-BUG-01 is fixed: async_migrate_entry no longer raises AttributeError.
 
-    This test documents the regression without the __setattr__ workaround patch.
-    It is expected to xfail until the implementation is fixed.
+    The fix replaced direct `entry.version = N` assignments with version=N kwarg
+    on async_update_entry(), which is the only supported way to change version in
+    HA >= 2026.x. This test confirms migration completes without error.
     """
     from custom_components.volkswagencarnet import async_migrate_entry
 
@@ -623,7 +613,7 @@ async def test_nal05_migration_version_assignment_raises(hass: HomeAssistant):
     )
     with patch("homeassistant.config_entries.ConfigEntries._async_schedule_save"):
         entry.add_to_hass(hass)
-        # Without the __setattr__ workaround, this raises AttributeError
+        # With the fix, this completes without raising AttributeError
         await async_migrate_entry(hass, entry)
 
 

--- a/tests/test_na_integration.py
+++ b/tests/test_na_integration.py
@@ -1,0 +1,1011 @@
+"""Tests for Phase 2 NA Library Integration (NAL gaps 01-05).
+
+Coverage:
+  NAL-01: Forked library dependency in requirements.txt and manifest.json
+  NAL-02: Country selector in config flow DATA_SCHEMA
+  NAL-03: country= parameter forwarded to Connection() in config flow and coordinator
+  NAL-05: v3 -> v4 migration (CONF_REGION -> CONF_COUNTRY, repair issue, ConfirmCountryRepairFlow)
+
+ESCALATE: IMPL-BUG-01
+  async_migrate_entry (__init__.py lines 150/162/171) uses the pattern:
+      version = entry.version = N
+  Direct assignment to ConfigEntry.version is forbidden in
+  homeassistant >= 2026.x (config_entries.py: UPDATE_ENTRY_CONFIG_ENTRY_ATTRS guard).
+  This will raise AttributeError at runtime for any v1, v2 or v3 entry migration.
+  Fix: replace `entry.version = N` with `hass.config_entries.async_update_entry(entry, version=N, ...)`
+  The migration tests in this file use a __setattr__ patch to bypass the guard and still
+  exercise the underlying migration logic.  See test_nal05_migration_version_assignment_raises
+  for the failing baseline test that documents the bug.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.volkswagencarnet.const import (
+    CONF_COUNTRY,
+    CONF_COUNTRY_CUSTOM,
+    CONF_REGION,
+    COUNTRY_LIST,
+    DEFAULT_COUNTRY,
+    DOMAIN,
+)
+
+# Root of the repository (two levels up from this test file)
+REPO_ROOT = Path(__file__).parent.parent
+
+FORKED_GIT_URL = "git+https://github.com/Pascal-ZeGerman/volkswagencarnet"
+
+
+# ===========================================================================
+# GAP 1: NAL-01 — Forked library dependency
+# ===========================================================================
+
+
+def test_nal01_requirements_txt_has_forked_git_url():
+    """requirements.txt must reference the forked GitHub URL."""
+    req_file = REPO_ROOT / "requirements.txt"
+    assert req_file.exists(), "requirements.txt not found in repo root"
+    content = req_file.read_text()
+    assert FORKED_GIT_URL in content, (
+        f"requirements.txt does not contain forked git URL '{FORKED_GIT_URL}'.\n"
+        f"Actual content:\n{content}"
+    )
+
+
+def test_nal01_manifest_requirements_has_forked_git_url():
+    """manifest.json requirements array must reference the forked GitHub URL."""
+    manifest_file = (
+        REPO_ROOT / "custom_components" / "volkswagencarnet" / "manifest.json"
+    )
+    assert manifest_file.exists(), "manifest.json not found"
+    manifest = json.loads(manifest_file.read_text())
+    requirements = manifest.get("requirements", [])
+    assert isinstance(requirements, list), "manifest.json 'requirements' must be a list"
+    matching = [r for r in requirements if FORKED_GIT_URL in r]
+    assert matching, (
+        f"manifest.json requirements do not contain forked git URL '{FORKED_GIT_URL}'.\n"
+        f"Actual requirements: {requirements}"
+    )
+
+
+def test_nal01_requirements_and_manifest_in_sync():
+    """The forked git requirement spec in requirements.txt and manifest.json must match."""
+    req_content = (REPO_ROOT / "requirements.txt").read_text()
+    manifest = json.loads(
+        (REPO_ROOT / "custom_components" / "volkswagencarnet" / "manifest.json").read_text()
+    )
+
+    req_lines = [line.strip() for line in req_content.splitlines() if FORKED_GIT_URL in line]
+    assert req_lines, "No matching line in requirements.txt"
+    req_spec = req_lines[0]
+
+    manifest_reqs = manifest.get("requirements", [])
+    manifest_matching = [r for r in manifest_reqs if FORKED_GIT_URL in r]
+    assert manifest_matching, "No matching entry in manifest.json requirements"
+    manifest_spec = manifest_matching[0]
+
+    assert req_spec == manifest_spec, (
+        f"Mismatch between requirements.txt and manifest.json:\n"
+        f"  requirements.txt: {req_spec}\n"
+        f"  manifest.json:    {manifest_spec}"
+    )
+
+
+# ===========================================================================
+# GAP 2: NAL-02 — Country selector in config flow DATA_SCHEMA
+# ===========================================================================
+
+
+def test_nal02_country_list_has_16_entries():
+    """COUNTRY_LIST must contain exactly 15 named countries plus 'OTHER'."""
+    assert len(COUNTRY_LIST) == 16, (
+        f"Expected 16 entries in COUNTRY_LIST, got {len(COUNTRY_LIST)}.\n"
+        f"Keys: {list(COUNTRY_LIST.keys())}"
+    )
+
+
+def test_nal02_country_list_contains_other():
+    """COUNTRY_LIST must include the sentinel 'OTHER' key."""
+    assert "OTHER" in COUNTRY_LIST, "COUNTRY_LIST missing 'OTHER' key"
+
+
+def test_nal02_country_list_contains_expected_country_codes():
+    """COUNTRY_LIST must include both NA (US, CA) and major EU country codes."""
+    expected = {"US", "CA", "DE", "GB", "NL", "SE", "NO", "FR", "IT", "ES"}
+    missing = expected - set(COUNTRY_LIST.keys())
+    assert not missing, f"COUNTRY_LIST is missing expected country codes: {missing}"
+
+
+def test_nal02_data_schema_has_required_country_field():
+    """DATA_SCHEMA must declare CONF_COUNTRY as vol.Required."""
+    from custom_components.volkswagencarnet.config_flow import DATA_SCHEMA
+
+    schema_keys = {key.schema: key for key in DATA_SCHEMA.schema}
+    assert CONF_COUNTRY in schema_keys, (
+        f"DATA_SCHEMA does not have '{CONF_COUNTRY}' key.\n"
+        f"Available keys: {list(schema_keys.keys())}"
+    )
+    key_obj = schema_keys[CONF_COUNTRY]
+    assert isinstance(key_obj, vol.Required), (
+        f"'{CONF_COUNTRY}' in DATA_SCHEMA must be vol.Required, "
+        f"got {type(key_obj).__name__}"
+    )
+
+
+def test_nal02_data_schema_country_accepts_all_country_list_values():
+    """The DATA_SCHEMA validator for CONF_COUNTRY must accept every key in COUNTRY_LIST."""
+    from custom_components.volkswagencarnet.config_flow import DATA_SCHEMA
+
+    # Find the validator for CONF_COUNTRY
+    validator = None
+    for key in DATA_SCHEMA.schema:
+        if key.schema == CONF_COUNTRY:
+            validator = DATA_SCHEMA.schema[key]
+            break
+
+    assert validator is not None, f"No validator found for {CONF_COUNTRY}"
+
+    for code in COUNTRY_LIST:
+        try:
+            validator(code)
+        except vol.Invalid as exc:
+            pytest.fail(
+                f"COUNTRY_LIST key '{code}' was rejected by DATA_SCHEMA validator: {exc}"
+            )
+
+
+def test_nal02_data_schema_country_rejects_invalid_value():
+    """The DATA_SCHEMA validator for CONF_COUNTRY must reject values not in COUNTRY_LIST."""
+    from custom_components.volkswagencarnet.config_flow import DATA_SCHEMA
+
+    validator = None
+    for key in DATA_SCHEMA.schema:
+        if key.schema == CONF_COUNTRY:
+            validator = DATA_SCHEMA.schema[key]
+            break
+
+    assert validator is not None
+
+    with pytest.raises(vol.Invalid):
+        validator("INVALID_CODE_XYZ")
+
+
+def test_nal02_data_schema_has_optional_country_custom_field():
+    """DATA_SCHEMA must declare CONF_COUNTRY_CUSTOM as vol.Optional."""
+    from custom_components.volkswagencarnet.config_flow import DATA_SCHEMA
+
+    schema_keys = {key.schema: key for key in DATA_SCHEMA.schema}
+    assert CONF_COUNTRY_CUSTOM in schema_keys, (
+        f"DATA_SCHEMA does not have '{CONF_COUNTRY_CUSTOM}' key.\n"
+        f"Available keys: {list(schema_keys.keys())}"
+    )
+    key_obj = schema_keys[CONF_COUNTRY_CUSTOM]
+    assert isinstance(key_obj, vol.Optional), (
+        f"'{CONF_COUNTRY_CUSTOM}' in DATA_SCHEMA must be vol.Optional, "
+        f"got {type(key_obj).__name__}"
+    )
+
+
+async def test_nal02_other_collapse_accepts_valid_2char_code(hass: HomeAssistant):
+    """async_step_user: CONF_COUNTRY='OTHER' with a valid 2-char custom code is accepted."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+
+    user_input = {
+        "name": "",
+        "username": "user@example.com",
+        "password": "secret",
+        "spin": "",
+        CONF_COUNTRY: "OTHER",
+        CONF_COUNTRY_CUSTOM: "AU",
+        "mutable": True,
+        "convert": "no_conversion",
+        "scan_interval": 5,
+    }
+
+    with patch.object(flow, "async_show_form", return_value={"type": "form", "step_id": "user"}) as mock_form, \
+         patch.object(flow, "async_step_login", new=AsyncMock(return_value={"type": "form"})):
+        await flow.async_step_user(user_input)
+
+    # The form must NOT have been called with invalid_country_code error
+    for c in mock_form.call_args_list:
+        errors = c.kwargs.get("errors", {})
+        assert errors.get(CONF_COUNTRY_CUSTOM) != "invalid_country_code", (
+            "Valid 2-char country code 'AU' was incorrectly rejected"
+        )
+
+    # After collapse, CONF_COUNTRY must be the custom code, CONF_COUNTRY_CUSTOM removed
+    assert flow._init_info.get(CONF_COUNTRY) == "AU", (
+        f"Expected CONF_COUNTRY='AU' after collapse, got {flow._init_info.get(CONF_COUNTRY)!r}"
+    )
+    assert CONF_COUNTRY_CUSTOM not in flow._init_info, (
+        "CONF_COUNTRY_CUSTOM must be removed from _init_info after collapse"
+    )
+
+
+async def test_nal02_other_collapse_rejects_non_2char_code(hass: HomeAssistant):
+    """async_step_user: CONF_COUNTRY='OTHER' with non-2-char code must show invalid_country_code error."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+    for bad_code in ["", "A", "AUS", "AUSTRALIA"]:
+        flow = VolkswagenCarnetConfigFlow()
+        flow.hass = hass
+
+        user_input = {
+            "name": "",
+            "username": "user@example.com",
+            "password": "secret",
+            "spin": "",
+            CONF_COUNTRY: "OTHER",
+            CONF_COUNTRY_CUSTOM: bad_code,
+            "mutable": True,
+            "convert": "no_conversion",
+            "scan_interval": 5,
+        }
+
+        with patch.object(flow, "async_show_form", return_value={"type": "form", "step_id": "user"}) as mock_form:
+            await flow.async_step_user(user_input)
+
+        assert mock_form.called, f"async_show_form not called for bad_code={bad_code!r}"
+        errors = mock_form.call_args.kwargs.get("errors", {})
+        assert errors.get(CONF_COUNTRY_CUSTOM) == "invalid_country_code", (
+            f"Expected 'invalid_country_code' error for bad_code={bad_code!r}, "
+            f"got errors={errors}"
+        )
+
+
+async def test_nal02_other_collapse_strips_whitespace_and_uppercases(hass: HomeAssistant):
+    """async_step_user: custom code whitespace is stripped and value is uppercased."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+
+    user_input = {
+        "name": "",
+        "username": "user@example.com",
+        "password": "secret",
+        "spin": "",
+        CONF_COUNTRY: "OTHER",
+        CONF_COUNTRY_CUSTOM: "  nz  ",  # lowercase, surrounded by whitespace
+        "mutable": True,
+        "convert": "no_conversion",
+        "scan_interval": 5,
+    }
+
+    with patch.object(flow, "async_show_form") as mock_form, \
+         patch.object(flow, "async_step_login", new=AsyncMock(return_value={"type": "form"})):
+        await flow.async_step_user(user_input)
+
+    # No error should be shown
+    for c in mock_form.call_args_list:
+        errors = c.kwargs.get("errors", {})
+        assert errors.get(CONF_COUNTRY_CUSTOM) != "invalid_country_code", (
+            "Whitespace-padded lowercase 2-char code should be accepted after stripping"
+        )
+
+    assert flow._init_info.get(CONF_COUNTRY) == "NZ", (
+        f"Expected CONF_COUNTRY='NZ' after stripping+uppercasing, "
+        f"got {flow._init_info.get(CONF_COUNTRY)!r}"
+    )
+
+
+# ===========================================================================
+# GAP 3: NAL-03 — country= parameter passed to Connection()
+# ===========================================================================
+
+
+async def test_nal03_config_flow_passes_country_us_to_connection(hass: HomeAssistant):
+    """Connection() in async_step_user must receive country='US' when US is selected."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        conn = MagicMock()
+        conn.logged_in = False
+        conn.vehicles = []
+        return conn
+
+    user_input = {
+        "name": "",
+        "username": "user@example.com",
+        "password": "secret",
+        "spin": "",
+        CONF_COUNTRY: "US",
+        CONF_COUNTRY_CUSTOM: "",
+        "mutable": True,
+        "convert": "no_conversion",
+        "scan_interval": 5,
+    }
+
+    with patch("custom_components.volkswagencarnet.config_flow.Connection", side_effect=fake_connection), \
+         patch.object(flow, "async_step_login", new=AsyncMock(return_value={"type": "form"})):
+        await flow.async_step_user(user_input)
+
+    assert "country" in captured_kwargs, (
+        "Connection() was not called with 'country' keyword argument"
+    )
+    assert captured_kwargs["country"] == "US", (
+        f"Expected country='US', got country={captured_kwargs['country']!r}"
+    )
+
+
+async def test_nal03_config_flow_passes_country_ca_to_connection(hass: HomeAssistant):
+    """Connection() in async_step_user must receive country='CA' when Canada is selected."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        conn = MagicMock()
+        conn.logged_in = False
+        conn.vehicles = []
+        return conn
+
+    user_input = {
+        "name": "",
+        "username": "user@example.com",
+        "password": "secret",
+        "spin": "",
+        CONF_COUNTRY: "CA",
+        CONF_COUNTRY_CUSTOM: "",
+        "mutable": True,
+        "convert": "no_conversion",
+        "scan_interval": 5,
+    }
+
+    with patch("custom_components.volkswagencarnet.config_flow.Connection", side_effect=fake_connection), \
+         patch.object(flow, "async_step_login", new=AsyncMock(return_value={"type": "form"})):
+        await flow.async_step_user(user_input)
+
+    assert captured_kwargs.get("country") == "CA", (
+        f"Expected country='CA', got country={captured_kwargs.get('country')!r}"
+    )
+
+
+async def test_nal03_coordinator_passes_country_to_connection(hass: HomeAssistant):
+    """VolkswagenCoordinator must pass country= from entry.data[CONF_COUNTRY] to Connection()."""
+    from datetime import timedelta
+
+    from custom_components.volkswagencarnet import VolkswagenCoordinator
+
+
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_COUNTRY: "US",
+        },
+    )
+
+    with patch("custom_components.volkswagencarnet.Connection", side_effect=fake_connection):
+        VolkswagenCoordinator(hass=hass, entry=entry, update_interval=timedelta(minutes=5))
+
+    assert "country" in captured_kwargs, (
+        "VolkswagenCoordinator did not pass 'country' to Connection()"
+    )
+    assert captured_kwargs["country"] == "US", (
+        f"Expected country='US', got country={captured_kwargs['country']!r}"
+    )
+
+
+async def test_nal03_coordinator_falls_back_to_conf_region(hass: HomeAssistant):
+    """Coordinator must fall back to CONF_REGION value if CONF_COUNTRY is absent."""
+    from datetime import timedelta
+
+    from custom_components.volkswagencarnet import VolkswagenCoordinator
+
+
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    # Simulate an old v3 entry that was not yet migrated (no CONF_COUNTRY)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "NO",
+        },
+    )
+
+    with patch("custom_components.volkswagencarnet.Connection", side_effect=fake_connection):
+        VolkswagenCoordinator(hass=hass, entry=entry, update_interval=timedelta(minutes=5))
+
+    assert captured_kwargs.get("country") == "NO", (
+        f"Expected fallback country='NO' from CONF_REGION, got {captured_kwargs.get('country')!r}"
+    )
+
+
+async def test_nal03_coordinator_falls_back_to_default_country(hass: HomeAssistant):
+    """Coordinator must use DEFAULT_COUNTRY if neither CONF_COUNTRY nor CONF_REGION is set."""
+    from datetime import timedelta
+
+    from custom_components.volkswagencarnet import VolkswagenCoordinator
+
+
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            # Neither CONF_COUNTRY nor CONF_REGION present
+        },
+    )
+
+    with patch("custom_components.volkswagencarnet.Connection", side_effect=fake_connection):
+        VolkswagenCoordinator(hass=hass, entry=entry, update_interval=timedelta(minutes=5))
+
+    assert captured_kwargs.get("country") == DEFAULT_COUNTRY, (
+        f"Expected default country='{DEFAULT_COUNTRY}', got {captured_kwargs.get('country')!r}"
+    )
+
+
+async def test_nal03_reauth_passes_country_from_entry_data(hass: HomeAssistant):
+    """async_step_reauth_confirm must forward CONF_COUNTRY from entry.data to Connection()."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "old_user@example.com",
+            "password": "oldpassword",
+            CONF_COUNTRY: "SE",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+    flow._entry = entry
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        conn = MagicMock()
+        conn.doLogin = AsyncMock(return_value=True)
+        conn.logged_in = False
+        conn.validate_login = AsyncMock(return_value=False)
+        return conn
+
+    with patch("custom_components.volkswagencarnet.config_flow.Connection", side_effect=fake_connection):
+        await flow.async_step_reauth_confirm(
+            user_input={
+                "username": "new_user@example.com",
+                "password": "newpassword",
+            }
+        )
+
+    assert captured_kwargs.get("country") == "SE", (
+        f"Reauth did not forward CONF_COUNTRY='SE' to Connection(), "
+        f"got {captured_kwargs.get('country')!r}"
+    )
+
+
+async def test_nal03_reauth_falls_back_to_conf_region_if_no_conf_country(hass: HomeAssistant):
+    """async_step_reauth_confirm must fall back to CONF_REGION if CONF_COUNTRY is absent."""
+    from custom_components.volkswagencarnet.config_flow import VolkswagenCarnetConfigFlow
+
+
+    # Old-style entry with only CONF_REGION
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "old@example.com",
+            "password": "old",
+            CONF_REGION: "FI",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = VolkswagenCarnetConfigFlow()
+    flow.hass = hass
+    flow._entry = entry
+    captured_kwargs: dict = {}
+
+    def fake_connection(**kwargs):
+        captured_kwargs.update(kwargs)
+        conn = MagicMock()
+        conn.doLogin = AsyncMock(return_value=True)
+        conn.logged_in = False
+        conn.validate_login = AsyncMock(return_value=False)
+        return conn
+
+    with patch("custom_components.volkswagencarnet.config_flow.Connection", side_effect=fake_connection):
+        await flow.async_step_reauth_confirm(
+            user_input={"username": "u@example.com", "password": "pw"}
+        )
+
+    assert captured_kwargs.get("country") == "FI", (
+        f"Expected CONF_REGION fallback 'FI', got {captured_kwargs.get('country')!r}"
+    )
+
+
+# ===========================================================================
+# GAP 4: NAL-05 — Migration v3 → v4
+# ===========================================================================
+
+
+async def _run_migration(hass: HomeAssistant, entry):
+    """Helper: add entry to hass and invoke async_migrate_entry.
+
+    NOTE: The implementation uses the now-forbidden direct assignment pattern
+    ``entry.version = N`` (must use async_update_entry instead).  We patch
+    ConfigEntry.__setattr__ to bypass the guard so the migration *logic* can
+    still be exercised. The underlying bug is tracked as ESCALATE:
+    IMPL-BUG-01 (see module docstring).
+    """
+    from custom_components.volkswagencarnet import async_migrate_entry
+    from homeassistant.config_entries import ConfigEntry
+
+    _orig_setattr = ConfigEntry.__setattr__
+
+    def _permissive_setattr(self, key, value):
+        # Allow 'version' to be set directly (bypass the guard for test purposes)
+        if key == "version":
+            object.__setattr__(self, key, value)
+        else:
+            _orig_setattr(self, key, value)
+
+    with patch("homeassistant.config_entries.ConfigEntries._async_schedule_save"), \
+         patch.object(ConfigEntry, "__setattr__", _permissive_setattr):
+        entry.add_to_hass(hass)
+        return await async_migrate_entry(hass, entry)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "ESCALATE IMPL-BUG-01: async_migrate_entry uses the forbidden direct "
+        "`entry.version = N` assignment pattern. HA >= 2026.x enforces that version "
+        "can only be changed via async_update_entry(entry, version=N). "
+        "Fix: use hass.config_entries.async_update_entry(entry, version=4, data=data, options=options) "
+        "and remove the `entry.version = 4` direct assignment in __init__.py."
+    ),
+    raises=AttributeError,
+    strict=True,
+)
+async def test_nal05_migration_version_assignment_raises(hass: HomeAssistant):
+    """ESCALATE IMPL-BUG-01: direct entry.version assignment raises AttributeError in HA >= 2026.x.
+
+    This test documents the regression without the __setattr__ workaround patch.
+    It is expected to xfail until the implementation is fixed.
+    """
+    from custom_components.volkswagencarnet import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "DE",
+        },
+    )
+    with patch("homeassistant.config_entries.ConfigEntries._async_schedule_save"):
+        entry.add_to_hass(hass)
+        # Without the __setattr__ workaround, this raises AttributeError
+        await async_migrate_entry(hass, entry)
+
+
+async def test_nal05_migration_returns_true(hass: HomeAssistant):
+    """async_migrate_entry must return True for a v3 config entry."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "DE",
+        },
+    )
+    result = await _run_migration(hass, entry)
+    assert result is True, "async_migrate_entry returned False for v3 entry"
+
+
+async def test_nal05_version_bumped_to_4(hass: HomeAssistant):
+    """Config entry version must be 4 after v3 migration."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "GB",
+        },
+    )
+    await _run_migration(hass, entry)
+    assert entry.version == 4, (
+        f"Expected entry.version == 4 after migration, got {entry.version}"
+    )
+
+
+async def test_nal05_conf_region_renamed_to_conf_country_in_data(hass: HomeAssistant):
+    """CONF_REGION in entry.data must become CONF_COUNTRY='NL' after migration."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "NL",
+        },
+    )
+    await _run_migration(hass, entry)
+
+    assert CONF_COUNTRY in entry.data, (
+        f"'{CONF_COUNTRY}' not in entry.data after migration"
+    )
+    assert entry.data[CONF_COUNTRY] == "NL", (
+        f"Expected CONF_COUNTRY='NL', got {entry.data.get(CONF_COUNTRY)!r}"
+    )
+    assert CONF_REGION not in entry.data, (
+        f"'{CONF_REGION}' still present in entry.data after migration"
+    )
+
+
+async def test_nal05_missing_region_defaults_to_default_country(hass: HomeAssistant):
+    """If CONF_REGION absent from data, CONF_COUNTRY must default to DEFAULT_COUNTRY."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            # No CONF_REGION
+        },
+    )
+    await _run_migration(hass, entry)
+
+    assert entry.data.get(CONF_COUNTRY) == DEFAULT_COUNTRY, (
+        f"Expected CONF_COUNTRY='{DEFAULT_COUNTRY}' when CONF_REGION absent, "
+        f"got {entry.data.get(CONF_COUNTRY)!r}"
+    )
+
+
+async def test_nal05_conf_region_renamed_in_options(hass: HomeAssistant):
+    """CONF_REGION in entry.options must be renamed to CONF_COUNTRY after migration."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "SE",
+        },
+        options={
+            CONF_REGION: "SE",
+            "resources": ["position"],
+        },
+    )
+    await _run_migration(hass, entry)
+
+    assert CONF_COUNTRY in entry.options, (
+        f"'{CONF_COUNTRY}' not in entry.options after migration"
+    )
+    assert entry.options[CONF_COUNTRY] == "SE", (
+        f"Expected CONF_COUNTRY='SE' in options, got {entry.options.get(CONF_COUNTRY)!r}"
+    )
+    assert CONF_REGION not in entry.options, (
+        f"'{CONF_REGION}' still in entry.options after migration"
+    )
+
+
+async def test_nal05_options_other_keys_preserved(hass: HomeAssistant):
+    """Keys in options other than CONF_REGION must survive migration unchanged."""
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "FR",
+        },
+        options={
+            "resources": ["position", "door_locked"],
+            "available_resources": {"position": "Position"},
+        },
+    )
+    await _run_migration(hass, entry)
+
+    assert entry.options.get("resources") == ["position", "door_locked"], (
+        "Migration must preserve 'resources' in options"
+    )
+    assert "available_resources" in entry.options, (
+        "Migration must preserve 'available_resources' in options"
+    )
+
+
+async def test_nal05_repair_issue_created(hass: HomeAssistant):
+    """async_migrate_entry must call ir.async_create_issue with a confirm_country_ issue ID."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "AT",
+        },
+    )
+
+    with patch("homeassistant.helpers.issue_registry.async_create_issue") as mock_create_issue:
+        await _run_migration(hass, entry)
+
+    assert mock_create_issue.called, "ir.async_create_issue was not called during migration"
+    args = mock_create_issue.call_args.args
+    assert args[0] is hass, "async_create_issue: first arg must be hass"
+    assert args[1] == DOMAIN, f"async_create_issue: domain must be '{DOMAIN}'"
+    issue_id = args[2]
+    assert issue_id.startswith("confirm_country_"), (
+        f"Repair issue_id must start with 'confirm_country_', got '{issue_id}'"
+    )
+    assert entry.entry_id in issue_id, (
+        f"Repair issue_id must contain entry_id '{entry.entry_id}'"
+    )
+
+
+async def test_nal05_repair_issue_data_has_entry_id_and_country(hass: HomeAssistant):
+    """The repair issue data dict must include 'entry_id' and 'country'."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "CH",
+        },
+    )
+
+    with patch("homeassistant.helpers.issue_registry.async_create_issue") as mock_create_issue:
+        await _run_migration(hass, entry)
+
+    issue_data = mock_create_issue.call_args.kwargs.get("data", {})
+    assert issue_data.get("entry_id") == entry.entry_id, (
+        f"Repair issue data['entry_id'] must be '{entry.entry_id}', got {issue_data.get('entry_id')!r}"
+    )
+    assert issue_data.get("country") == "CH", (
+        f"Repair issue data['country'] must be 'CH', got {issue_data.get('country')!r}"
+    )
+
+
+async def test_nal05_repair_issue_is_fixable_with_warning_severity(hass: HomeAssistant):
+    """The repair issue must be is_fixable=True with IssueSeverity.WARNING."""
+    from homeassistant.helpers import issue_registry as ir
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_REGION: "DK",
+        },
+    )
+
+    with patch("homeassistant.helpers.issue_registry.async_create_issue") as mock_create_issue:
+        await _run_migration(hass, entry)
+
+    kwargs = mock_create_issue.call_args.kwargs
+    assert kwargs.get("is_fixable") is True, (
+        f"Repair issue must have is_fixable=True, got {kwargs.get('is_fixable')!r}"
+    )
+    assert kwargs.get("severity") == ir.IssueSeverity.WARNING, (
+        f"Repair issue must have severity=WARNING, got {kwargs.get('severity')!r}"
+    )
+
+
+# ===========================================================================
+# GAP 4 (continued): NAL-05 — ConfirmCountryRepairFlow
+# ===========================================================================
+
+
+def test_nal05_async_create_fix_flow_returns_confirm_country_repair_flow():
+    """async_create_fix_flow must return ConfirmCountryRepairFlow for confirm_country_ IDs."""
+    from custom_components.volkswagencarnet.repairs import (
+        ConfirmCountryRepairFlow,
+        async_create_fix_flow,
+    )
+
+    hass = MagicMock()
+    data = {"entry_id": "abc123", "country": "DE"}
+
+    result = asyncio.get_event_loop().run_until_complete(
+        async_create_fix_flow(hass, "confirm_country_abc123", data)
+    )
+
+    assert isinstance(result, ConfirmCountryRepairFlow), (
+        f"Expected ConfirmCountryRepairFlow, got {type(result).__name__}"
+    )
+
+
+def test_nal05_async_create_fix_flow_raises_for_unknown_issue():
+    """async_create_fix_flow must raise ValueError for unrecognised issue IDs."""
+    from custom_components.volkswagencarnet.repairs import async_create_fix_flow
+
+    hass = MagicMock()
+
+    with pytest.raises(ValueError, match="Unknown repair issue id"):
+        asyncio.get_event_loop().run_until_complete(
+            async_create_fix_flow(hass, "unknown_issue_xyz", {})
+        )
+
+
+def test_nal05_repair_flow_stores_entry_id_and_country():
+    """ConfirmCountryRepairFlow.__init__ must store entry_id and existing_country from data."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+    flow = ConfirmCountryRepairFlow({"entry_id": "test_entry_123", "country": "SE"})
+
+    assert flow._entry_id == "test_entry_123", (
+        f"Expected _entry_id='test_entry_123', got {flow._entry_id!r}"
+    )
+    assert flow._existing_country == "SE", (
+        f"Expected _existing_country='SE', got {flow._existing_country!r}"
+    )
+
+
+def test_nal05_repair_flow_uses_safe_defaults_for_empty_data():
+    """ConfirmCountryRepairFlow must use safe defaults when initialized with an empty dict."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+    flow = ConfirmCountryRepairFlow({})
+
+    assert flow._entry_id == "", f"Expected empty _entry_id, got {flow._entry_id!r}"
+    assert flow._existing_country == "DE", (
+        f"Expected _existing_country='DE' (default), got {flow._existing_country!r}"
+    )
+
+
+async def test_nal05_repair_flow_confirm_shows_form_with_prepopulated_country(hass: HomeAssistant):
+    """async_step_confirm(user_input=None) must show a form with CONF_COUNTRY pre-populated."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+    flow = ConfirmCountryRepairFlow({"entry_id": "my_entry", "country": "NO"})
+    flow.hass = hass
+
+    result = await flow.async_step_confirm(user_input=None)
+
+    # Result type 1 == FORM in HA's FlowResultType enum
+    assert result.get("type") in ("form", 1), (
+        f"Expected form result type, got {result.get('type')!r} (full result: {result})"
+    )
+    assert result.get("step_id") == "confirm", (
+        f"Expected step_id='confirm', got {result.get('step_id')!r}"
+    )
+
+    schema = result.get("data_schema")
+    assert schema is not None, "Form result must include data_schema"
+
+    schema_keys = {key.schema: key for key in schema.schema}
+    assert CONF_COUNTRY in schema_keys, (
+        f"Form schema must include '{CONF_COUNTRY}', available: {list(schema_keys.keys())}"
+    )
+    country_key = schema_keys[CONF_COUNTRY]
+    assert isinstance(country_key, vol.Required), (
+        "CONF_COUNTRY in repair form schema must be vol.Required"
+    )
+    assert country_key.default() == "NO", (
+        f"CONF_COUNTRY default must be 'NO' (pre-populated), got {country_key.default()!r}"
+    )
+
+
+async def test_nal05_repair_flow_confirm_updates_entry_on_submit(hass: HomeAssistant):
+    """Submitting the repair form must update the config entry with the chosen country."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "vehicle": "WVWZZZ3BZWE689325",
+            "username": "user@example.com",
+            "password": "secret",
+            CONF_COUNTRY: "DE",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = ConfirmCountryRepairFlow({"entry_id": entry.entry_id, "country": "DE"})
+    flow.hass = hass
+
+    with patch.object(hass.config_entries, "async_reload", new=AsyncMock()):
+        result = await flow.async_step_confirm(user_input={CONF_COUNTRY: "US"})
+
+    updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated_entry.data.get(CONF_COUNTRY) == "US", (
+        f"Repair flow did not update CONF_COUNTRY to 'US' in entry.data; "
+        f"got {updated_entry.data.get(CONF_COUNTRY)!r}"
+    )
+    # Result type 5 == CREATE_ENTRY in HA's FlowResultType enum
+    assert result.get("type") in ("create_entry", 5), (
+        f"Expected create_entry result, got {result.get('type')!r}"
+    )
+
+
+async def test_nal05_repair_flow_init_redirects_to_confirm(hass: HomeAssistant):
+    """async_step_init must redirect to the 'confirm' step."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+    flow = ConfirmCountryRepairFlow({"entry_id": "irrelevant", "country": "FI"})
+    flow.hass = hass
+
+    result = await flow.async_step_init(user_input=None)
+
+    assert result.get("step_id") == "confirm", (
+        f"async_step_init must redirect to 'confirm', got step_id={result.get('step_id')!r}"
+    )
+
+
+async def test_nal05_repair_flow_confirm_handles_missing_entry_gracefully(hass: HomeAssistant):
+    """If the config entry no longer exists, the repair flow must still complete without raising."""
+    from custom_components.volkswagencarnet.repairs import ConfirmCountryRepairFlow
+
+    flow = ConfirmCountryRepairFlow({"entry_id": "nonexistent_entry_id", "country": "BE"})
+    flow.hass = hass
+
+    # Must not raise; should return create_entry
+    result = await flow.async_step_confirm(user_input={CONF_COUNTRY: "BE"})
+
+    assert result.get("type") in ("create_entry", 5), (
+        f"Expected create_entry even for missing entry, got {result.get('type')!r}"
+    )


### PR DESCRIPTION
## Summary

- Trigger changed from manual GitHub release UI → `git push tag v*` automation
- Auto-detects pre-releases: tags ending in `-rc`, `-alpha`, or `-beta` are marked as pre-release
- Switched to `softprops/action-gh-release@v2` which creates the release and uploads the zip in one step, plus auto-generates release notes from merged PR titles
- Both third-party actions pinned to immutable commit SHAs (supply chain hardening)
- All `github.ref_name` interpolations moved to `env:` vars to avoid shell injection

## How to release going forward

```bash
git tag v5.5.0 && git push origin v5.5.0
# pre-release:
git tag v5.5.0-rc.1 && git push origin v5.5.0-rc.1
```

## Test Plan

- [ ] Merge PR
- [ ] Push a test tag (`v0.0.0-rc.1`) and verify workflow runs, creates a pre-release, and attaches the zip